### PR TITLE
Add duration and target SOC UI for schedule commands

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "react-router-dom": "^7.7.0",
       },
       "devDependencies": {
-        "@newtown-energy/types": "^0.1.4",
+        "@newtown-energy/types": "^0.1.5",
         "@types/jest": "^29.5.14",
         "@types/node": "^24.0.10",
         "@types/react": "^19.1.8",
@@ -311,7 +311,7 @@
 
     "@mui/x-internals": ["@mui/x-internals@8.26.0", "", { "dependencies": { "@babel/runtime": "^7.28.4", "@mui/utils": "^7.3.5", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-B9OZau5IQUvIxwpJZhoFJKqRpmWf5r0yMmSXjQuqb5WuqM755EuzWJOenY48denGoENzMLT8hQpA0hRTeU2IPA=="],
 
-    "@newtown-energy/types": ["@newtown-energy/types@0.1.4", "https://npm.pkg.github.com/download/@newtown-energy/types/0.1.4/f2d88bc02a3122e3dff94834494e28f70d2e2a94", {}, "sha512-hV9nkuKSAT2lSFfO6AwBbbfGTzKBVL4Y580ddSSPuppymRPEtuBq9uBZvT6t30hfWa6N7LrLBNTcxeF/WurwHQ=="],
+    "@newtown-energy/types": ["@newtown-energy/types@0.1.5", "https://npm.pkg.github.com/download/@newtown-energy/types/0.1.5/ccfa99632030f467b2a8ee36d2e04e93b0cdff80", {}, "sha512-WxcZM8/EOYMDoLagURjISWnuHuBW71nrhDCoEpC+3o/LggDz9woCA5o+p8xZz3RofJi5/du/lv3UxWDmsW+FRg=="],
 
     "@parcel/watcher": ["@parcel/watcher@2.5.6", "", { "dependencies": { "detect-libc": "^2.0.3", "is-glob": "^4.0.3", "node-addon-api": "^7.0.0", "picomatch": "^4.0.3" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.6", "@parcel/watcher-darwin-arm64": "2.5.6", "@parcel/watcher-darwin-x64": "2.5.6", "@parcel/watcher-freebsd-x64": "2.5.6", "@parcel/watcher-linux-arm-glibc": "2.5.6", "@parcel/watcher-linux-arm-musl": "2.5.6", "@parcel/watcher-linux-arm64-glibc": "2.5.6", "@parcel/watcher-linux-arm64-musl": "2.5.6", "@parcel/watcher-linux-x64-glibc": "2.5.6", "@parcel/watcher-linux-x64-musl": "2.5.6", "@parcel/watcher-win32-arm64": "2.5.6", "@parcel/watcher-win32-ia32": "2.5.6", "@parcel/watcher-win32-x64": "2.5.6" } }, "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ=="],
 
@@ -637,7 +637,7 @@
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
-    "convert-source-map": ["convert-source-map@1.9.0", "", {}, "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="],
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -1527,13 +1527,13 @@
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "@babel/core/convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
-
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@emotion/babel-plugin/convert-source-map": ["convert-source-map@1.9.0", "", {}, "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="],
 
     "@emotion/babel-plugin/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
 
@@ -1554,8 +1554,6 @@
     "@istanbuljs/load-nyc-config/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "@istanbuljs/load-nyc-config/resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
-
-    "@jest/transform/convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -1624,8 +1622,6 @@
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
-
-    "v8-to-istanbul/convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react-router-dom": "^7.7.0"
   },
   "devDependencies": {
-    "@newtown-energy/types": "^0.1.4",
+    "@newtown-energy/types": "^0.1.5",
     "@types/jest": "^29.5.14",
     "@types/node": "^24.0.10",
     "@types/react": "^19.1.8",

--- a/src/components/CommandCalendar/CommandCalendar.tsx
+++ b/src/components/CommandCalendar/CommandCalendar.tsx
@@ -52,7 +52,9 @@ import {
   isPastDate,
   secondsToTime,
   getCommandTypeLabel,
-  getCommandTypeColor
+  getCommandTypeColor,
+  formatDuration,
+  formatSoC
 } from '../../utils/scheduleHelpers';
 import { debugLog } from '../../utils/debug';
 
@@ -563,6 +565,8 @@ const CommandCalendar: React.FC<CommandCalendarProps> = ({
                         <TableRow>
                           <TableCell>Time</TableCell>
                           <TableCell>Type</TableCell>
+                          <TableCell>Duration</TableCell>
+                          <TableCell>Target SOC</TableCell>
                         </TableRow>
                       </TableHead>
                       <TableBody>
@@ -576,6 +580,8 @@ const CommandCalendar: React.FC<CommandCalendarProps> = ({
                                 size="small"
                               />
                             </TableCell>
+                            <TableCell>{formatDuration(command.duration_seconds)}</TableCell>
+                            <TableCell>{formatSoC(command.target_soc_percent)}</TableCell>
                           </TableRow>
                         ))}
                       </TableBody>

--- a/src/components/ScheduleLibrary/ScheduleLibrary.tsx
+++ b/src/components/ScheduleLibrary/ScheduleLibrary.tsx
@@ -60,7 +60,11 @@ import {
   timeToSeconds,
   getCommandTypeLabel,
   getCommandTypeColor,
-  formatDaysOfWeek
+  formatDaysOfWeek,
+  formatDuration,
+  formatSoC,
+  durationToSeconds,
+  secondsToDuration
 } from '../../utils/scheduleHelpers';
 import { debugLog } from '../../utils/debug';
 
@@ -105,6 +109,9 @@ const ScheduleLibrary: React.FC<ScheduleLibraryProps> = ({
   const [commandMinute, setCommandMinute] = useState(0);
   const [commandType, setCommandType] = useState<'charge' | 'discharge' | 'trickle_charge'>('charge');
   const [isCommandInlineEdit, setIsCommandInlineEdit] = useState(false);
+  const [commandDurationHours, setCommandDurationHours] = useState<number | null>(null);
+  const [commandDurationMinutes, setCommandDurationMinutes] = useState<number | null>(null);
+  const [commandTargetSoc, setCommandTargetSoc] = useState<number | null>(null);
 
   // Specific dates viewer
   const [specificDatesDialogOpen, setSpecificDatesDialogOpen] = useState(false);
@@ -281,6 +288,9 @@ const ScheduleLibrary: React.FC<ScheduleLibraryProps> = ({
     setCommandHour(0);
     setCommandMinute(0);
     setCommandType('charge');
+    setCommandDurationHours(null);
+    setCommandDurationMinutes(null);
+    setCommandTargetSoc(null);
     setIsCommandInlineEdit(isInlineEdit);
     setCommandDialogOpen(true);
   };
@@ -295,6 +305,17 @@ const ScheduleLibrary: React.FC<ScheduleLibraryProps> = ({
     setCommandHour(hours);
     setCommandMinute(minutes);
     setCommandType(command.command_type);
+    // Set duration fields
+    if (command.duration_seconds !== null && command.duration_seconds !== undefined) {
+      const duration = secondsToDuration(command.duration_seconds);
+      setCommandDurationHours(duration.hours);
+      setCommandDurationMinutes(duration.minutes);
+    } else {
+      setCommandDurationHours(null);
+      setCommandDurationMinutes(null);
+    }
+    // Set target SOC
+    setCommandTargetSoc(command.target_soc_percent ?? null);
     setCommandDialogOpen(true);
   };
 
@@ -311,7 +332,7 @@ const ScheduleLibrary: React.FC<ScheduleLibraryProps> = ({
     const specificDateRules = rules.filter(r => r.rule_type === 'specific_date');
     const allDates = specificDateRules.flatMap(rule => rule.specific_dates || []);
     // Sort dates chronologically
-    allDates.sort();
+    allDates.sort((a, b) => a.localeCompare(b));
     setViewingSpecificDates(allDates);
     setSpecificDatesDialogOpen(true);
   };
@@ -332,10 +353,25 @@ const ScheduleLibrary: React.FC<ScheduleLibraryProps> = ({
       return;
     }
 
+    // Calculate duration in seconds if hours or minutes are set
+    let durationSeconds: number | null = null;
+    if (commandDurationHours !== null || commandDurationMinutes !== null) {
+      durationSeconds = durationToSeconds(
+        commandDurationHours ?? 0,
+        commandDurationMinutes ?? 0
+      );
+      // Don't allow 0 duration
+      if (durationSeconds === 0) {
+        durationSeconds = null;
+      }
+    }
+
     const newCommand: ScheduleCommandDto = {
       id: editingCommandIndex !== null ? commands[editingCommandIndex].id : Date.now(),
       execution_offset_seconds: offsetSeconds,
-      command_type: commandType
+      command_type: commandType,
+      duration_seconds: durationSeconds,
+      target_soc_percent: commandTargetSoc
     };
 
     if (editingCommandIndex !== null) {
@@ -568,6 +604,8 @@ const ScheduleLibrary: React.FC<ScheduleLibraryProps> = ({
                               <TableRow>
                                 <TableCell>Time</TableCell>
                                 <TableCell>Type</TableCell>
+                                <TableCell>Duration</TableCell>
+                                <TableCell>Target SOC</TableCell>
                                 {isEditing && <TableCell align="right">Actions</TableCell>}
                               </TableRow>
                             </TableHead>
@@ -582,6 +620,8 @@ const ScheduleLibrary: React.FC<ScheduleLibraryProps> = ({
                                       size="small"
                                     />
                                   </TableCell>
+                                  <TableCell>{formatDuration(command.duration_seconds)}</TableCell>
+                                  <TableCell>{formatSoC(command.target_soc_percent)}</TableCell>
                                   {isEditing && (
                                     <TableCell align="right">
                                       <IconButton size="small" onClick={() => handleEditCommand(index, true)}>
@@ -665,6 +705,8 @@ const ScheduleLibrary: React.FC<ScheduleLibraryProps> = ({
                     <TableRow>
                       <TableCell>Time</TableCell>
                       <TableCell>Type</TableCell>
+                      <TableCell>Duration</TableCell>
+                      <TableCell>Target SOC</TableCell>
                       <TableCell align="right">Actions</TableCell>
                     </TableRow>
                   </TableHead>
@@ -679,6 +721,8 @@ const ScheduleLibrary: React.FC<ScheduleLibraryProps> = ({
                             size="small"
                           />
                         </TableCell>
+                        <TableCell>{formatDuration(command.duration_seconds)}</TableCell>
+                        <TableCell>{formatSoC(command.target_soc_percent)}</TableCell>
                         <TableCell align="right">
                           <IconButton size="small" onClick={() => handleEditCommand(index)}>
                             <EditIcon fontSize="small" />
@@ -725,7 +769,9 @@ const ScheduleLibrary: React.FC<ScheduleLibraryProps> = ({
         </DialogTitle>
         <DialogContent>
           <Box sx={{ pt: 2 }}>
-            <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
+            {/* Execution Time */}
+            <Typography variant="subtitle2" sx={{ mb: 1 }}>Execution Time</Typography>
+            <Box sx={{ display: 'flex', gap: 2, mb: 3 }}>
               <FormControl fullWidth>
                 <InputLabel>Hour</InputLabel>
                 <Select
@@ -756,18 +802,78 @@ const ScheduleLibrary: React.FC<ScheduleLibraryProps> = ({
               </FormControl>
             </Box>
 
-            <FormControl fullWidth>
+            {/* Command Type */}
+            <FormControl fullWidth sx={{ mb: 3 }}>
               <InputLabel>Command Type</InputLabel>
               <Select
                 value={commandType}
                 label="Command Type"
-                onChange={e => setCommandType(e.target.value as any)}
+                onChange={e => setCommandType(e.target.value as 'charge' | 'discharge' | 'trickle_charge')}
               >
                 <MenuItem value="charge">Charge</MenuItem>
                 <MenuItem value="discharge">Discharge</MenuItem>
                 <MenuItem value="trickle_charge">Trickle Charge</MenuItem>
               </Select>
             </FormControl>
+
+            {/* Duration (optional) */}
+            <Typography variant="subtitle2" sx={{ mb: 1 }}>Duration (optional)</Typography>
+            <Box sx={{ display: 'flex', gap: 2, mb: 3 }}>
+              <FormControl fullWidth>
+                <InputLabel>Hours</InputLabel>
+                <Select
+                  value={commandDurationHours ?? ''}
+                  label="Hours"
+                  onChange={e => setCommandDurationHours(e.target.value === '' as unknown ? null : Number(e.target.value))}
+                >
+                  <MenuItem value="">-</MenuItem>
+                  {Array.from({ length: 24 }, (_, i) => (
+                    <MenuItem key={i} value={i}>
+                      {i}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <FormControl fullWidth>
+                <InputLabel>Minutes</InputLabel>
+                <Select
+                  value={commandDurationMinutes ?? ''}
+                  label="Minutes"
+                  onChange={e => setCommandDurationMinutes(e.target.value === '' as unknown ? null : Number(e.target.value))}
+                >
+                  <MenuItem value="">-</MenuItem>
+                  {[0, 15, 30, 45].map(m => (
+                    <MenuItem key={m} value={m}>
+                      {m}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Box>
+
+            {/* Target SOC (optional) */}
+            <Typography variant="subtitle2" sx={{ mb: 1 }}>Target State of Charge (optional)</Typography>
+            <TextField
+              fullWidth
+              type="number"
+              label="Target SOC %"
+              value={commandTargetSoc ?? ''}
+              onChange={e => {
+                const value = e.target.value;
+                if (value === '') {
+                  setCommandTargetSoc(null);
+                } else {
+                  const num = parseInt(value, 10);
+                  if (!isNaN(num) && num >= 0 && num <= 100) {
+                    setCommandTargetSoc(num);
+                  }
+                }
+              }}
+              InputProps={{
+                inputProps: { min: 0, max: 100 }
+              }}
+              helperText="Enter a value between 0 and 100"
+            />
           </Box>
         </DialogContent>
         <DialogActions>

--- a/src/utils/scheduleHelpers.ts
+++ b/src/utils/scheduleHelpers.ts
@@ -139,6 +139,77 @@ export function getCommandTypes(): CommandType[] {
 }
 
 /**
+ * Format duration in seconds to human-readable string
+ *
+ * @param durationSeconds - Duration in seconds, or null
+ * @returns Human-readable duration string (e.g., "2h 30m") or "-" for null
+ *
+ * @example
+ * formatDuration(null)    // "-"
+ * formatDuration(3600)    // "1h"
+ * formatDuration(5400)    // "1h 30m"
+ * formatDuration(1800)    // "30m"
+ */
+export function formatDuration(durationSeconds: number | null): string {
+  if (durationSeconds === null) return '-';
+  const hours = Math.floor(durationSeconds / 3600);
+  const minutes = Math.floor((durationSeconds % 3600) / 60);
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  return `${minutes}m`;
+}
+
+/**
+ * Format state of charge percentage
+ *
+ * @param socPercent - SOC percentage (0-100), or null
+ * @returns Formatted SOC string (e.g., "85%") or "-" for null
+ *
+ * @example
+ * formatSoC(null)   // "-"
+ * formatSoC(0)      // "0%"
+ * formatSoC(85)     // "85%"
+ * formatSoC(100)    // "100%"
+ */
+export function formatSoC(socPercent: number | null): string {
+  if (socPercent === null) return '-';
+  return `${socPercent}%`;
+}
+
+/**
+ * Convert hours and minutes to total seconds
+ *
+ * @param hours - Hours component
+ * @param minutes - Minutes component
+ * @returns Total duration in seconds
+ *
+ * @example
+ * durationToSeconds(1, 30)  // 5400
+ * durationToSeconds(0, 45)  // 2700
+ */
+export function durationToSeconds(hours: number, minutes: number): number {
+  return hours * 3600 + minutes * 60;
+}
+
+/**
+ * Convert duration in seconds to hours and minutes components
+ *
+ * @param seconds - Total duration in seconds
+ * @returns Object with hours and minutes components
+ *
+ * @example
+ * secondsToDuration(5400)  // { hours: 1, minutes: 30 }
+ * secondsToDuration(2700)  // { hours: 0, minutes: 45 }
+ */
+export function secondsToDuration(seconds: number): { hours: number; minutes: number } {
+  return {
+    hours: Math.floor(seconds / 3600),
+    minutes: Math.floor((seconds % 3600) / 60)
+  };
+}
+
+/**
  * Format Date to ISO date string (YYYY-MM-DD)
  *
  * @param date - Date object


### PR DESCRIPTION
Frontend updates for schedule command duration and target SOC:
- Add helper functions: formatDuration, formatSoC, durationToSeconds, secondsToDuration
- Add Duration and Target SOC columns to command tables
- Add duration (hours/minutes) and target SOC inputs to command dialog
- Fix pre-existing lint issue with sort compare function

Resolves Newtown-Energy/neems-core#36