### PR TITLE
Fix tsconfig.app.json types fallback path

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -15,13 +15,11 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
-    /* Local types resolution (falls back to published package) */
+    /* Redirect to local-types during Docker dev; falls through to the
+       published package in node_modules when local-types is absent. */
     "baseUrl": ".",
     "paths": {
-      "@newtown-energy/types": [
-        "../local-types",
-        "./node_modules/@newtown-energy/types/dist"
-      ]
+      "@newtown-energy/types": ["../local-types"]
     },
 
     /* Linting */


### PR DESCRIPTION
## Summary
- Remove the broken `./node_modules/@newtown-energy/types/dist` fallback from `tsconfig.app.json` paths
- Path resolution now points only at `../local-types`; with `moduleResolution: "bundler"`, TypeScript falls through to standard `node_modules` resolution (which honors the published package's `types` field) when `local-types/` is absent
- Update the surrounding comment to reflect the new behavior

Closes #56

## Test plan
- [x] `bun run lint:tsc` passes
- [ ] CI build passes (host resolution against published `@newtown-energy/types`)
- [ ] Docker dev still resolves types via `local-types/` symlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)