### PR TITLE
Make dosh stat invocation portable across GNU and BSD

### DIFF
--- a/bin/dosh
+++ b/bin/dosh
@@ -6,6 +6,13 @@ SCRIPTNAME=`basename "$0"`
 BASEDIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/..
 cd ${BASEDIR}
 
+# `stat` flag for mtime-as-epoch differs between GNU coreutils (Linux) and BSD (macOS)
+if stat --version >/dev/null 2>&1; then
+    STAT_MTIME=(-c '%Y')
+else
+    STAT_MTIME=(-f '%m')
+fi
+
 build() {
     # Build for prod
 
@@ -15,18 +22,18 @@ build() {
     [ -d node_modules ] || { bun run build; exit 0; }
 
     # Get the latest timestamps (in seconds since epoch) for each directory tree
-    dist_t=$(find "dist" -type d -exec stat -c '%Y' {} + | sort -nr | head -n 1)
+    dist_t=$(find "dist" -type d -exec stat "${STAT_MTIME[@]}" {} + | sort -nr | head -n 1)
     [ -z "$dist_t" ] && { bun run build; exit 0; }
 
     # Cheapest find first
-    cur_dir_t=$(find . -maxdepth 1 -type f -exec stat -c '%Y' {} + | sort -nr | head -n 1)
+    cur_dir_t=$(find . -maxdepth 1 -type f -exec stat "${STAT_MTIME[@]}" {} + | sort -nr | head -n 1)
     [ "$cur_dir_t" -gt "$dist_t" ] && { echo "some config file is older than src, so rebuilding"; bun run build; exit 0; }
 
-    src_t=$(find "src" -type f -exec stat -c '%Y' {} + | sort -nr | head -n 1)
+    src_t=$(find "src" -type f -exec stat "${STAT_MTIME[@]}" {} + | sort -nr | head -n 1)
     [ "$src_t" -gt "$dist_t" ] && { echo "dist is older than src, so rebuilding"; bun run build; exit 0; }
 
     # Most expensive find last
-    node_modules_t=$(find "node_modules" -type d -exec stat -c '%Y' {} + | sort -nr | head -n 1)
+    node_modules_t=$(find "node_modules" -type d -exec stat "${STAT_MTIME[@]}" {} + | sort -nr | head -n 1)
     [ -z "$node_modules_t" ] && { bun run build; exit 0; }
     [ "$node_modules_t" -gt "$dist_t" ] && { echo "dist is older than node_modules, so rebuilding"; bun run build; exit 0; }
 


### PR DESCRIPTION
## Summary
- `bin/dosh` used `stat -c '%Y'`, which is GNU coreutils-only. On macOS the build-cache check silently failed.
- Detect GNU vs BSD `stat` once at script start and dispatch via a `STAT_MTIME` bash array.

Closes #55

## Test plan
- [x] `bash -n bin/dosh` — syntax check
- [x] `bash bin/dosh build` on macOS — triggers rebuild path correctly
- [x] `bash bin/dosh build` again — hits "dist is newer than src, skipping rebuild" path
- [ ] CI / Linux build still works (GNU branch unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)