### PR TITLE
Route console warn/error through debug.ts helpers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,7 +67,6 @@ const AppContent: React.FC = () => {
 };
 
 const App: React.FC = () => {
-  console.log(`React app running on ${window.location.protocol}//${window.location.host}`);
   debugLog('Router: App initializing', {
     host: window.location.host,
     protocol: window.location.protocol,

--- a/src/components/ApplicationRuleDialog/ApplicationRuleDialog.tsx
+++ b/src/components/ApplicationRuleDialog/ApplicationRuleDialog.tsx
@@ -42,6 +42,7 @@ import {
   createApplicationRule,
   deleteApplicationRule
 } from '../../utils/scheduleApi';
+import { errorLog } from '../../utils/debug';
 
 interface ApplicationRuleDialogProps {
   open: boolean;
@@ -105,7 +106,7 @@ const ApplicationRuleDialog: React.FC<ApplicationRuleDialogProps> = ({
       setSpecificDateRules(specificRules);
     } catch (err) {
       setError('Failed to load rules');
-      console.error('Error loading rules:', err);
+      errorLog('Error loading rules:', err);
     } finally {
       setLoading(false);
     }
@@ -145,7 +146,7 @@ const ApplicationRuleDialog: React.FC<ApplicationRuleDialogProps> = ({
       onRulesChanged?.();
     } catch (err) {
       setError('Failed to update recurring rules');
-      console.error('Error updating recurring rules:', err);
+      errorLog('Error updating recurring rules:', err);
       // Reload to restore previous state
       await loadRules();
     } finally {
@@ -162,7 +163,7 @@ const ApplicationRuleDialog: React.FC<ApplicationRuleDialogProps> = ({
       onRulesChanged?.();
     } catch (err) {
       setError('Failed to delete date override');
-      console.error('Error deleting date override:', err);
+      errorLog('Error deleting date override:', err);
     } finally {
       setLoading(false);
     }

--- a/src/components/CommandCalendar/CommandCalendar.tsx
+++ b/src/components/CommandCalendar/CommandCalendar.tsx
@@ -56,7 +56,7 @@ import {
   formatDuration,
   formatSoC
 } from '../../utils/scheduleHelpers';
-import { debugLog } from '../../utils/debug';
+import { debugLog, errorLog } from '../../utils/debug';
 
 interface CommandCalendarProps {
   siteId: number;
@@ -130,7 +130,7 @@ const CommandCalendar: React.FC<CommandCalendarProps> = ({
       setCalendarData(dataMap);
     } catch (err) {
       setError('Failed to load calendar data');
-      console.error('Error loading calendar:', err);
+      errorLog('Error loading calendar:', err);
       debugLog('CommandCalendar: Error loading calendar', err);
     } finally {
       setLoading(false);
@@ -172,7 +172,7 @@ const CommandCalendar: React.FC<CommandCalendarProps> = ({
         onDateSelect?.(selectedDate, null);
       }
     } catch (err) {
-      console.error('Error loading selected date:', err);
+      errorLog('Error loading selected date:', err);
       debugLog('CommandCalendar: Error loading selected date', err);
     }
   };
@@ -413,7 +413,7 @@ const CommandCalendar: React.FC<CommandCalendarProps> = ({
       // Then reload the calendar month to update the grid
       await loadCalendarMonth();
     } catch (err) {
-      console.error('Error switching to schedule:', err);
+      errorLog('Error switching to schedule:', err);
       setError('Failed to switch schedule');
     }
   };

--- a/src/components/CompanySelector/CompanySelector.tsx
+++ b/src/components/CompanySelector/CompanySelector.tsx
@@ -11,7 +11,7 @@ import { Business } from '@mui/icons-material';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { apiRequestWithMapping } from '../../utils/api';
 import type { Company } from '@newtown-energy/types';
-import { debugLog } from '../../utils/debug';
+import { debugLog, errorLog } from '../../utils/debug';
 
 interface CompanySelectorProps {
   collapsed: boolean;
@@ -86,7 +86,7 @@ export const CompanySelector: React.FC<CompanySelectorProps> = ({
       });
       setCompanies(data);
     } catch (err) {
-      console.error('Error fetching companies:', err);
+      errorLog('Error fetching companies:', err);
       debugLog('CompanySelector: Error fetching companies', err);
       setCompanies([]);
     } finally {

--- a/src/components/EditConfirmationDialog/EditConfirmationDialog.tsx
+++ b/src/components/EditConfirmationDialog/EditConfirmationDialog.tsx
@@ -24,6 +24,7 @@ import {
 import type { ScheduleLibraryItem } from '@newtown-energy/types';
 import { getLibraryItems } from '../../utils/scheduleApi';
 import { formatScheduleDate } from '../../utils/scheduleHelpers';
+import { errorLog } from '../../utils/debug';
 
 /**
  * Generates a unique copy name with incrementing version numbers.
@@ -98,7 +99,7 @@ const EditConfirmationDialog: React.FC<EditConfirmationDialogProps> = ({
           setCopyName(nextName);
           setNameError('');
         } catch (err) {
-          console.error('Error generating copy name:', err);
+          errorLog('Error generating copy name:', err);
           // Fallback to simple copy name
           setCopyName(`${libraryItem.name} (2)`);
           setNameError('');

--- a/src/components/ScheduleLibrary/ScheduleLibrary.tsx
+++ b/src/components/ScheduleLibrary/ScheduleLibrary.tsx
@@ -66,7 +66,7 @@ import {
   durationToSeconds,
   secondsToDuration
 } from '../../utils/scheduleHelpers';
-import { debugLog } from '../../utils/debug';
+import { debugLog, errorLog } from '../../utils/debug';
 
 interface ScheduleLibraryProps {
   siteId: number;
@@ -136,7 +136,7 @@ const ScheduleLibrary: React.FC<ScheduleLibraryProps> = ({
       setLibraryItems(items);
     } catch (err) {
       setError('Failed to load library items');
-      console.error('Error loading library items:', err);
+      errorLog('Error loading library items:', err);
       debugLog('ScheduleLibrary: Error loading library items', err);
     } finally {
       setLoading(false);
@@ -158,7 +158,7 @@ const ScheduleLibrary: React.FC<ScheduleLibraryProps> = ({
       });
       setAllRules(rules);
     } catch (err) {
-      console.error('Error loading rules:', err);
+      errorLog('Error loading rules:', err);
       debugLog('ScheduleLibrary: Error loading rules', err);
     }
   };
@@ -228,7 +228,7 @@ const ScheduleLibrary: React.FC<ScheduleLibraryProps> = ({
       await loadAllRules();
     } catch (err) {
       setError('Failed to update library item');
-      console.error('Error updating library item:', err);
+      errorLog('Error updating library item:', err);
     } finally {
       setLoading(false);
     }
@@ -258,7 +258,7 @@ const ScheduleLibrary: React.FC<ScheduleLibraryProps> = ({
       await loadLibraryItems();
     } catch (err) {
       setError('Failed to create library item');
-      console.error('Error creating library item:', err);
+      errorLog('Error creating library item:', err);
     } finally {
       setLoading(false);
     }
@@ -277,7 +277,7 @@ const ScheduleLibrary: React.FC<ScheduleLibraryProps> = ({
       await loadAllRules(); // Reload rules since they're deleted with the item
     } catch (err) {
       setError('Failed to delete library item');
-      console.error('Error deleting library item:', err);
+      errorLog('Error deleting library item:', err);
     } finally {
       setLoading(false);
     }

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -6,7 +6,7 @@ import { SidebarItem } from './SidebarItem';
 import { getPageConfig } from '../../config/pageRegistry';
 import { CompanySelector } from '../CompanySelector/CompanySelector';
 import { useAuth } from '../../pages/LoginPage/useAuth';
-import { debugLog } from '../../utils/debug';
+import { debugLog, errorLog } from '../../utils/debug';
 
 interface SidebarProps {
   className?: string;
@@ -80,11 +80,11 @@ const Sidebar: React.FC<SidebarProps> = () => { // Removed unused className
         debugLog('Sidebar: Logout successful, reloading page');
         window.location.reload();
       } else {
-        console.error('Logout failed:', response.statusText);
+        errorLog('Logout failed:', response.statusText);
         debugLog('Sidebar: Logout failed', { status: response.status, statusText: response.statusText });
       }
     } catch (error) {
-      console.error('Logout error:', error);
+      errorLog('Logout error:', error);
       debugLog('Sidebar: Logout error', error);
     }
   };

--- a/src/components/SingleLineDiagram/useSldAlarms.ts
+++ b/src/components/SingleLineDiagram/useSldAlarms.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { fetchActiveAlarms } from '../../utils/alarmApi';
+import { errorLog } from '../../utils/debug';
 import type { SldAction } from './sldState';
 
 const POLL_INTERVAL_MS = 10_000;
@@ -26,7 +27,7 @@ export function useSldAlarms(
           dispatch({ type: 'UPDATE_ALARMS', alarms: response });
         }
       } catch (err) {
-        console.error('SLD alarm poll failed:', err);
+        errorLog('SLD alarm poll failed:', err);
         if (mounted) {
           dispatch({ type: 'MARK_STALE' });
         }

--- a/src/components/SiteSelector/SiteSelector.tsx
+++ b/src/components/SiteSelector/SiteSelector.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mui/material';
 import { apiRequestWithMapping, ApiError } from '../../utils/api';
 import type { Site } from '@newtown-energy/types';
-import { debugLog } from '../../utils/debug';
+import { debugLog, errorLog } from '../../utils/debug';
 
 interface SiteSelectorProps {
   selectedSiteId: number | null;
@@ -58,7 +58,7 @@ const SiteSelector: React.FC<SiteSelectorProps> = ({
         onSiteChange(data[0].id);
       }
     } catch (err) {
-      console.error('Error fetching sites:', err);
+      errorLog('Error fetching sites:', err);
       debugLog('SiteSelector: Error fetching sites', err);
       if (err instanceof ApiError) {
         setError(`Failed to load sites: ${err.message}`);

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -35,7 +35,7 @@ import { useSearchParams } from 'react-router-dom';
 import type { User, Site, CompanyWithTimestamps, UserWithRolesAndTimestamps, CreateUserWithRolesRequest, UpdateUserRequest, CreateSiteRequest } from '@newtown-energy/types';
 import { apiRequestWithMapping, ApiError } from '../utils/api';
 import type { ODataQueryOptions } from '../utils/api';
-import { debugLog } from '../utils/debug';
+import { debugLog, errorLog } from '../utils/debug';
 
 
 
@@ -156,7 +156,7 @@ const AdminPage: React.FC = () => {
       }
     } catch (err) {
       setError('Error loading data');
-      console.error('Error fetching data:', err);
+      errorLog('Error fetching data:', err);
     } finally {
       setLoading(false);
     }
@@ -197,7 +197,7 @@ const AdminPage: React.FC = () => {
       });
       setUsers(usersWithCompanyNames);
     } catch (err) {
-      console.error('Error fetching users:', err);
+      errorLog('Error fetching users:', err);
       debugLog('AdminPage: Error fetching users', { companyId: selectedCompanyId, error: err });
       if (err instanceof ApiError) {
         setError(`Failed to load users: ${err.message}`);
@@ -235,7 +235,7 @@ const AdminPage: React.FC = () => {
       });
       setSites(transformedSites);
     } catch (err) {
-      console.error('Error fetching sites:', err);
+      errorLog('Error fetching sites:', err);
       debugLog('AdminPage: Error fetching sites', { companyId: selectedCompanyId, error: err });
       if (err instanceof ApiError) {
         setError(`Failed to load sites: ${err.message}`);
@@ -264,7 +264,7 @@ const AdminPage: React.FC = () => {
       });
       setCompanies(data);
     } catch (err) {
-      console.error('Error fetching companies:', err);
+      errorLog('Error fetching companies:', err);
       debugLog('AdminPage: Error fetching companies', err);
       if (err instanceof ApiError) {
         setError(`Failed to load companies: ${err.message}`);
@@ -345,7 +345,7 @@ const AdminPage: React.FC = () => {
         errorMessage = `Error ${editingUser ? 'updating' : 'creating'} user`;
       }
       setUserModalError(errorMessage);
-      console.error('Error saving user:', err);
+      errorLog('Error saving user:', err);
     } finally {
       setLoading(false);
     }
@@ -372,7 +372,7 @@ const AdminPage: React.FC = () => {
         errorMessage = 'Error deleting user';
       }
       setUserModalError(errorMessage);
-      console.error('Error deleting user:', err);
+      errorLog('Error deleting user:', err);
     } finally {
       setLoading(false);
     }
@@ -380,7 +380,7 @@ const AdminPage: React.FC = () => {
 
   const handlePasswordReset = async (userId: number) => {
     // Placeholder - doesn't do anything yet
-    console.log('Password reset requested for user:', userId);
+    debugLog('Password reset requested for user:', userId);
     setUserModalError('Password reset functionality coming soon');
   };
 
@@ -436,7 +436,7 @@ const AdminPage: React.FC = () => {
         errorMessage = `Error ${editingSite ? 'updating' : 'creating'} site`;
       }
       setSiteModalError(errorMessage);
-      console.error('Error saving site:', err);
+      errorLog('Error saving site:', err);
     } finally {
       setLoading(false);
     }
@@ -463,7 +463,7 @@ const AdminPage: React.FC = () => {
         errorMessage = 'Error deleting site';
       }
       setSiteModalError(errorMessage);
-      console.error('Error deleting site:', err);
+      errorLog('Error deleting site:', err);
     } finally {
       setLoading(false);
     }
@@ -509,7 +509,7 @@ const AdminPage: React.FC = () => {
         errorMessage = `Error ${editingCompany ? 'updating' : 'creating'} company`;
       }
       setCompanyModalError(errorMessage);
-      console.error('Error saving company:', err);
+      errorLog('Error saving company:', err);
     } finally {
       setLoading(false);
     }
@@ -536,7 +536,7 @@ const AdminPage: React.FC = () => {
         errorMessage = 'Error deleting company';
       }
       setCompanyModalError(errorMessage);
-      console.error('Error deleting company:', err);
+      errorLog('Error deleting company:', err);
     } finally {
       setLoading(false);
     }

--- a/src/pages/AlarmsPage.tsx
+++ b/src/pages/AlarmsPage.tsx
@@ -37,6 +37,7 @@ import {
   getSeverityOrder,
 } from '../utils/alarmHelpers';
 import { resolveAlarmSeverity } from '../config/siteConfig';
+import { errorLog } from '../utils/debug';
 
 export const pageConfig = {
   id: 'alarms',
@@ -87,7 +88,7 @@ const AlarmsPage: React.FC = () => {
         setHistory((h) => ({ ...h, [alarmNum]: { kind: 'loaded', entries: res.entries } })),
       )
       .catch((err) => {
-        console.error('Alarm history fetch failed:', err);
+        errorLog('Alarm history fetch failed:', err);
         setHistory((h) => ({
           ...h,
           [alarmNum]: { kind: 'error', message: 'Failed to load history' },
@@ -120,7 +121,7 @@ const AlarmsPage: React.FC = () => {
       setLastRefresh(new Date());
     } catch (err) {
       setError('Failed to load alarm data');
-      console.error('Error loading alarms:', err);
+      errorLog('Error loading alarms:', err);
     } finally {
       setLoading(false);
     }
@@ -130,7 +131,7 @@ const AlarmsPage: React.FC = () => {
     // Definitions are static — load once
     fetchAlarmDefinitions()
       .then(setDefinitions)
-      .catch((err) => console.error('Error loading alarm definitions:', err));
+      .catch((err) => errorLog('Error loading alarm definitions:', err));
 
     loadAlarms(true);
     const interval = setInterval(() => loadAlarms(), POLL_INTERVAL_MS);

--- a/src/pages/FDNYPage.tsx
+++ b/src/pages/FDNYPage.tsx
@@ -34,6 +34,7 @@ import {
   getSeverityColor,
 } from '../utils/alarmHelpers';
 import { resolveAlarmSeverity } from '../config/siteConfig';
+import { errorLog } from '../utils/debug';
 
 export const pageConfig = {
   id: 'fdny',
@@ -77,7 +78,7 @@ const FDNYPage: React.FC = () => {
   useEffect(() => {
     fetchAlarmDefinitions()
       .then((d) => setDefinitions(d.definitions))
-      .catch((err) => console.error('Error loading alarm definitions:', err));
+      .catch((err) => errorLog('Error loading alarm definitions:', err));
   }, []);
 
   const load = useCallback(async () => {
@@ -93,7 +94,7 @@ const FDNYPage: React.FC = () => {
       setLastRefresh(new Date());
     } catch (err) {
       setError('Failed to load alarm history');
-      console.error('Error loading alarm history:', err);
+      errorLog('Error loading alarm history:', err);
     } finally {
       setLoading(false);
     }

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -18,7 +18,6 @@ const LoginPage: React.FC<Props> = ({ onLoginSuccess }) => {
     setLoading(true);
 
     const requestBody = { email, password };
-    console.log("Sending login request with body:", requestBody);
     debugLog('LoginPage: Login attempt', { email });
 
     try {

--- a/src/pages/LoginPage/useAuth.ts
+++ b/src/pages/LoginPage/useAuth.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import type { LoginSuccessResponse } from "../../types/auth";
 import { apiRequest, ApiError } from "../../utils/api";
-import { debugLog } from "../../utils/debug";
+import { debugLog, errorLog } from "../../utils/debug";
 
 export function useAuth() {
   const [loading, setLoading] = useState(true);
@@ -82,7 +82,7 @@ export function useAuth() {
       });
       debugLog('useAuth: Logout API call successful');
     } catch (error) {
-      console.error('Logout request failed:', error);
+      errorLog('Logout request failed:', error);
       debugLog('useAuth: Logout API call failed', error);
     } finally {
       // Always clear user data and set as not authenticated, even if request fails

--- a/src/pages/OverviewPage.tsx
+++ b/src/pages/OverviewPage.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import type { ActiveAlarmsResponse } from '@newtown-energy/types';
 import { fetchActiveAlarms } from '../utils/alarmApi';
 import { formatAlarmName, getSeverityColor, getSeverityOrder, ZONE_DISPLAY_NAMES } from '../utils/alarmHelpers';
+import { errorLog } from '../utils/debug';
 
 export const pageConfig = {
   id: 'overview',
@@ -25,7 +26,7 @@ const OverviewPage: React.FC = () => {
       setAlarmError(null);
     } catch (err) {
       setAlarmError('Failed to load alarm data');
-      console.error('Error loading alarms:', err);
+      errorLog('Error loading alarms:', err);
     } finally {
       setAlarmLoading(false);
     }

--- a/src/pages/SchedulerPage.tsx
+++ b/src/pages/SchedulerPage.tsx
@@ -33,6 +33,7 @@ import {
   cloneLibraryItem,
   createApplicationRule
 } from '../utils/scheduleApi';
+import { errorLog } from '../utils/debug';
 import { toISODateString } from '../utils/scheduleHelpers';
 
 export const pageConfig = {
@@ -77,7 +78,7 @@ const SchedulerPage: React.FC = () => {
       const items = await getLibraryItems(HARDCODED_SITE_ID);
       setLibraryItems(items);
     } catch (err) {
-      console.error('Error loading library items:', err);
+      errorLog('Error loading library items:', err);
     }
   };
 
@@ -106,7 +107,7 @@ const SchedulerPage: React.FC = () => {
       // Refresh calendar
       setCalendarRefreshKey(prev => prev + 1);
     } catch (err) {
-      console.error('Error creating copy:', err);
+      errorLog('Error creating copy:', err);
     }
   };
 
@@ -140,7 +141,7 @@ const SchedulerPage: React.FC = () => {
       setApplyDifferentDialogOpen(false);
       setApplyOverrideReason('');
     } catch (err) {
-      console.error('Error applying schedule:', err);
+      errorLog('Error applying schedule:', err);
     }
   };
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,5 +1,5 @@
 import type { ErrorResponse } from '@newtown-energy/types';
-import { debugLog } from './debug';
+import { debugLog, warnLog, errorLog } from './debug';
 
 class ApiError extends Error {
   status: number;
@@ -92,7 +92,7 @@ export async function apiRequest<T = any>(
   
   // Log non-JSON responses for debugging
   if (!responseText.trim()) {
-    console.warn(`API returned empty response: ${response.status} ${response.statusText} for ${url}`);
+    warnLog(`API returned empty response: ${response.status} ${response.statusText} for ${url}`);
     if (response.ok) {
       return {} as T;
     } else {
@@ -105,7 +105,7 @@ export async function apiRequest<T = any>(
     data = JSON.parse(responseText);
   } catch (parseError) {
     // This should never happen with the updated backend, so log it
-    console.error('Non-JSON response received:', {
+    errorLog('Non-JSON response received:', {
       url,
       status: response.status,
       statusText: response.statusText,

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,38 +1,44 @@
 /**
- * Debug utility for conditional logging throughout the application.
+ * Logging utilities for the application.
  *
- * Debug mode can be enabled in two ways:
- * 1. Query string: ?debug=true
- * 2. localStorage: localStorage.setItem('debugSchedule', 'true')
+ * - debugLog: gated by debug mode (query string ?debug=true or
+ *   localStorage.debugSchedule === 'true'). Use for verbose tracing.
+ * - warnLog / errorLog: always log. Use for warnings and errors that should
+ *   be visible regardless of debug mode.
+ *
+ * Routing all console output through this module gives us a single place to
+ * change logging behavior (e.g. forward to a remote sink) later.
  *
  * Usage:
- *   import { debugLog } from '@/utils/debug';
+ *   import { debugLog, warnLog, errorLog } from '@/utils/debug';
  *   debugLog('Loading calendar for month:', currentMonth);
+ *   warnLog('Empty response from', url);
+ *   errorLog('Error fetching users:', err);
  */
 
-/**
- * Check if debug mode is enabled via query string or localStorage
- */
 export const isDebugEnabled = (): boolean => {
-  // Check query string
   const params = new URLSearchParams(window.location.search);
   if (params.get('debug') === 'true') {
     return true;
   }
 
-  // Check localStorage
   try {
     return localStorage.getItem('debugSchedule') === 'true';
-  } catch (e) {
+  } catch {
     return false;
   }
 };
 
-/**
- * Log a debug message if debug mode is enabled
- */
 export const debugLog = (...args: any[]): void => {
   if (isDebugEnabled()) {
     console.log('[DEBUG]', ...args);
   }
+};
+
+export const warnLog = (...args: any[]): void => {
+  console.warn(...args);
+};
+
+export const errorLog = (...args: any[]): void => {
+  console.error(...args);
 };


### PR DESCRIPTION
## Summary
- Add `warnLog` and `errorLog` to `src/utils/debug.ts` (alongside the existing `debugLog`).
- Convert every `console.warn` / `console.error` call site to use these helpers — gives us one place to change logging behavior (e.g. forward to a remote sink, silence in prod).
- Drop the boot-time `console.log` in `App.tsx`; the same info is already covered by `debugLog`.

## Test plan
- [ ] Trigger a known error path (e.g. unauthenticated API call) and confirm the message still appears in the browser console.
- [ ] Set `?debug=true` and confirm `debugLog` output still flows.
- [ ] `bun run lint:tsc` and `bun run lint:eslint` pass.
- [ ] Spot-check a couple of converted files (`src/utils/api.ts`, `src/pages/AlarmsPage.tsx`) — error handling unchanged, only the log call differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)