### PR TITLE
Replace any casts with generated types

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,7 +35,6 @@ export default defineConfig([
       '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/no-unnecessary-type-assertion': 'off',
       '@typescript-eslint/prefer-regexp-exec': 'off',
-      '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/prefer-optional-chain': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -32,13 +32,12 @@ import {
 import { Add, Edit, Delete, Refresh, Person, LocationOn, Business, AdminPanelSettings } from '@mui/icons-material';
 import { useAuth } from './LoginPage/useAuth';
 import { useSearchParams } from 'react-router-dom';
-import type { User, Site, CompanyWithTimestamps, UserWithRolesAndTimestamps, CreateUserWithRolesRequest, UpdateUserRequest, CreateSiteRequest } from '@newtown-energy/types';
+import type { Company, Site, CompanyWithTimestamps, UserWithRolesAndTimestamps, CreateUserWithRolesRequest, UpdateUserRequest, CreateSiteRequest } from '@newtown-energy/types';
 import { apiRequestWithMapping, ApiError } from '../utils/api';
 import type { ODataQueryOptions } from '../utils/api';
 import { debugLog, errorLog } from '../utils/debug';
 
-
-
+type UserWithExpandedCompany = UserWithRolesAndTimestamps & { Company?: Company };
 
 
 const formatDateTime = (dateString: string): string => {
@@ -184,11 +183,11 @@ const AdminPage: React.FC = () => {
         // $skip: 0, // Skip 0 users (for pagination)
         // $count: true // Include total count in response
       };
-      const data = await apiRequestWithMapping<User[]>(`/api/1/Companies/${selectedCompanyId}/Users`, {}, queryOptions);
+      const data = await apiRequestWithMapping<UserWithExpandedCompany[]>(`/api/1/Companies/${selectedCompanyId}/Users`, {}, queryOptions);
       // Transform API response - roles are now embedded, company may be expanded
-      const usersWithCompanyNames = data.map((user: any) => ({
+      const usersWithCompanyNames = data.map((user) => ({
         ...user,
-        company_name: (user.Company?.name) || companies.find(c => c.id === user.company_id)?.name || 'Unknown'
+        company_name: user.Company?.name || companies.find(c => c.id === user.company_id)?.name || 'Unknown'
       }));
       debugLog('AdminPage: Users loaded', {
         companyId: selectedCompanyId,
@@ -222,7 +221,7 @@ const AdminPage: React.FC = () => {
     try {
       const data = await apiRequestWithMapping<Site[]>(`/api/1/Companies/${selectedCompanyId}/Sites`);
       // Transform API response to match our interface
-      const transformedSites = data.map((site: any) => ({
+      const transformedSites = data.map((site) => ({
         ...site,
         location: site.address || `${site.latitude}, ${site.longitude}`,
         company_name: companies.find(c => c.id === site.company_id)?.name || 'Unknown',

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -100,7 +100,7 @@ export async function apiRequest<T = any>(
     }
   }
 
-  let data: any;
+  let data: unknown;
   try {
     data = JSON.parse(responseText);
   } catch (parseError) {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -51,7 +51,7 @@ function buildODataQuery(options: ODataQueryOptions): string {
   return queryString ? `?${queryString}` : '';
 }
 
-export async function apiRequest<T = any>(
+export async function apiRequest<T = unknown>(
   url: string,
   options: RequestInit = {}
 ): Promise<T> {
@@ -134,7 +134,7 @@ export async function apiRequest<T = any>(
 }
 
 // OData-aware API request for collections (automatically unwraps OData envelope)
-export async function apiRequestOData<T = any>(
+export async function apiRequestOData<T = unknown>(
   url: string,
   options: RequestInit = {},
   queryOptions?: ODataQueryOptions
@@ -238,7 +238,7 @@ function mapNavigationEndpoint(url: string): string {
 }
 
 // Enhanced API request that automatically maps old endpoints to new OData endpoints
-export async function apiRequestWithMapping<T = any>(
+export async function apiRequestWithMapping<T = unknown>(
   url: string,
   options: RequestInit = {},
   queryOptions?: ODataQueryOptions
@@ -264,7 +264,7 @@ export async function apiRequestWithMapping<T = any>(
 }
 
 // Convenience function for getting OData collections with count information
-export async function apiRequestODataWithCount<T = any>(
+export async function apiRequestODataWithCount<T = unknown>(
   url: string,
   options: RequestInit = {},
   queryOptions?: ODataQueryOptions

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -29,16 +29,16 @@ export const isDebugEnabled = (): boolean => {
   }
 };
 
-export const debugLog = (...args: any[]): void => {
+export const debugLog = (...args: unknown[]): void => {
   if (isDebugEnabled()) {
     console.log('[DEBUG]', ...args);
   }
 };
 
-export const warnLog = (...args: any[]): void => {
+export const warnLog = (...args: unknown[]): void => {
   console.warn(...args);
 };
 
-export const errorLog = (...args: any[]): void => {
+export const errorLog = (...args: unknown[]): void => {
   console.error(...args);
 };


### PR DESCRIPTION
## Summary
- `src/utils/api.ts:103` — `let data: any` → `let data: unknown` in the JSON parse path; existing `as T` / `as ErrorResponse` casts handle narrowing.
- `src/pages/AdminPage.tsx:189` — fetched users typed as `UserWithExpandedCompany[]` (a local `UserWithRolesAndTimestamps & { Company?: Company }` alias) so the OData `$expand=Company` field resolves without `any`.
- `src/pages/AdminPage.tsx:225` — drop `(site: any)`; `Site` already covers every field used.

Closes #53.

## Test plan
- [x] `bun run lint:tsc` passes
- [x] `bun run lint:eslint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)