### PR TITLE
Add E2E coverage for Scheduler, Library, Alarms, Sld

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,22 @@ jobs:
         env:
           GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: bun run build
+  tsc-tests:
+    # Type-check the Jest E2E test files so they don't bitrot. The tests
+    # themselves are not yet executed in CI (tracked in #69) — this catches
+    # broken imports and signature drift in the test suite.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: bun install
+        env:
+          GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: npm install
+        working-directory: test/jest
+      - run: npx tsc --noEmit -p test/jest/tsconfig.json

--- a/test/jest/package-lock.json
+++ b/test/jest/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "test",
+  "name": "jest",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/test/jest/tests/alarms-page.test.ts
+++ b/test/jest/tests/alarms-page.test.ts
@@ -1,0 +1,95 @@
+import {
+  navigateToApp,
+  loginAsSuperAdmin,
+} from './test-utils';
+
+describe('Alarms Page Tests', () => {
+  const baseUrl = `http://localhost:${process.env.NEEMS_REACT_PORT || '5173'}`;
+
+  it('should navigate to start page and log in', async () => {
+    await navigateToApp(page);
+    await loginAsSuperAdmin(page);
+  });
+
+  it('should load the Alarms page', async () => {
+    await page.goto(`${baseUrl}/alarms`);
+    // Either the alarms heading appears, or the initial loading spinner does.
+    await page.waitForFunction(
+      () => document.body.innerText.includes('Alarms'),
+      { timeout: 10000 }
+    );
+    expect(await page.url()).toContain('/alarms');
+  });
+
+  it('should render all four severity filter chips', async () => {
+    // After data loads, the severity summary chips appear.
+    await page.waitForFunction(
+      () => {
+        const text = document.body.innerText;
+        return text.includes('Emergency') && text.includes('Critical') && text.includes('Warning') && text.includes('Info');
+      },
+      { timeout: 15000 }
+    );
+
+    const chipLabels = await page.$$eval('.MuiChip-label', els =>
+      els.map(el => el.textContent || '')
+    );
+    expect(chipLabels.some(l => /Emergency/.test(l))).toBe(true);
+    expect(chipLabels.some(l => /Critical/.test(l))).toBe(true);
+    expect(chipLabels.some(l => /Warning/.test(l))).toBe(true);
+    expect(chipLabels.some(l => /Info/.test(l))).toBe(true);
+  });
+
+  it('should toggle a severity filter when a chip is clicked', async () => {
+    // Find and click the "Critical" chip.
+    const clicked = await page.evaluate(() => {
+      const chips = Array.from(document.querySelectorAll('.MuiChip-clickable')) as HTMLElement[];
+      const critical = chips.find(c => /Critical/.test(c.textContent || ''));
+      if (critical) {
+        critical.click();
+        return true;
+      }
+      return false;
+    });
+    expect(clicked).toBe(true);
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    // After toggling, a "Clear filters" chip appears.
+    const hasClearFilters = await page.evaluate(() => {
+      return document.body.innerText.includes('Clear filters');
+    });
+    expect(hasClearFilters).toBe(true);
+
+    // Toggle "Critical" again to untoggle and clear the filter.
+    await page.evaluate(() => {
+      const chips = Array.from(document.querySelectorAll('.MuiChip-clickable')) as HTMLElement[];
+      const critical = chips.find(c => /Critical/.test(c.textContent || ''));
+      critical?.click();
+    });
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    const stillHasClearFilters = await page.evaluate(() => document.body.innerText.includes('Clear filters'));
+    expect(stillHasClearFilters).toBe(false);
+  });
+
+  it('should expose the Filter by Zone dropdown', async () => {
+    const zoneLabel = await page.evaluate(() => {
+      const labels = Array.from(document.querySelectorAll('label'));
+      return labels.some(l => /Filter by Zone/.test(l.textContent || ''));
+    });
+    expect(zoneLabel).toBe(true);
+  });
+
+  it('should refresh data when the refresh button is clicked', async () => {
+    const refreshButton = await page.$('button[title="Refresh"]');
+    expect(refreshButton).not.toBeNull();
+    await refreshButton!.click();
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    // After refresh, the "Updated <time>" indicator should be present.
+    const hasUpdated = await page.evaluate(() => {
+      return /Updated /.test(document.body.innerText);
+    });
+    expect(hasUpdated).toBe(true);
+  });
+});

--- a/test/jest/tests/library-page.test.ts
+++ b/test/jest/tests/library-page.test.ts
@@ -1,0 +1,63 @@
+import {
+  navigateToApp,
+  loginAsSuperAdmin,
+  findButtonByText,
+} from './test-utils';
+
+describe('Library Page Tests', () => {
+  const baseUrl = `http://localhost:${process.env.NEEMS_REACT_PORT || '5173'}`;
+
+  it('should navigate to start page and log in', async () => {
+    await navigateToApp(page);
+    await loginAsSuperAdmin(page);
+  });
+
+  it('should load the Library page', async () => {
+    await page.goto(`${baseUrl}/library`);
+    await page.waitForFunction(
+      () => document.body.innerText.includes('Schedule Library'),
+      { timeout: 10000 }
+    );
+    expect(await page.url()).toContain('/library');
+  });
+
+  it('should render the Library heading and helper text', async () => {
+    const content = await page.content();
+    expect(content).toContain('Schedule Library');
+    expect(content).toContain('Library');
+    expect(content).toContain('Create and manage reusable schedules');
+  });
+
+  it('should expose the New Schedule action', async () => {
+    const newScheduleButton = await findButtonByText(page, ['New Schedule']);
+    expect(await newScheduleButton.evaluate((el: any) => !!el)).toBe(true);
+  });
+
+  it('should open and close the New Schedule dialog', async () => {
+    const newScheduleButton = await findButtonByText(page, ['New Schedule']);
+    await newScheduleButton.click();
+    await page.waitForSelector('[role="dialog"]', { timeout: 5000 });
+
+    // Dialog should expose Name and Description fields.
+    const dialogContent = await page.$eval('[role="dialog"]', el => el.textContent || '');
+    expect(dialogContent).toMatch(/Name/i);
+
+    // Close via Cancel.
+    const cancelButton = await findButtonByText(page, ['Cancel']);
+    expect(await cancelButton.evaluate((el: any) => !!el)).toBe(true);
+    await cancelButton.click();
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    const dialog = await page.$('[role="dialog"]');
+    expect(dialog).toBeNull();
+  });
+
+  it('should navigate back to the Scheduler via Back to Calendar', async () => {
+    const backButton = await findButtonByText(page, ['Back to Calendar']);
+    expect(await backButton.evaluate((el: any) => !!el)).toBe(true);
+    await backButton.click();
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    expect(await page.url()).toContain('/scheduler');
+  });
+});

--- a/test/jest/tests/neems-navigation.test.ts
+++ b/test/jest/tests/neems-navigation.test.ts
@@ -1,108 +1,97 @@
+/**
+ * Sidebar navigation tests.
+ *
+ * Verifies the NEEMS logo link, the Admin Panel sidebar item, and the
+ * primary nav items route to their expected paths. The legacy
+ * UserProfile dropdown was consolidated into the sidebar (commit 934d7c9).
+ */
 import {
-  clearBrowserState,
   navigateToApp,
-  navigateToAdmin,
-  findButtonByText,
-  loginAsUser,
   loginAsSuperAdmin,
-  createNetworkErrorHandler,
-  verifyEntityExists
 } from './test-utils';
 
+const baseUrl = `http://localhost:${process.env.NEEMS_REACT_PORT || '5173'}`;
 
 describe('NEEMS Navigation Tests', () => {
   beforeEach(async () => {
-    // Clear cookies to ensure clean state between tests
     const client = await page.target().createCDPSession();
     await client.send('Network.clearBrowserCookies');
     await client.send('Network.clearBrowserCache');
     await client.detach();
-
-    await page.goto(`http://localhost:${process.env.NEEMS_REACT_PORT || '5173'}`);
+    // Sidebar auto-collapses below 900px wide; expanded sidebar exposes labels.
+    await page.setViewport({ width: 1280, height: 800 });
+    await page.goto(baseUrl);
   });
 
-  it('should navigate to main page when NEEMS header is clicked', async () => {
+  it('should expose a NEEMS logo link to the root path', async () => {
     await loginAsSuperAdmin(page);
-   
-    // Navigate to a different page first (Super Admin)
-    await page.click('[data-testid="user-profile"]');
-    await new Promise(resolve => setTimeout(resolve, 500));
-    
-    // Click Admin menu item
-    const menuItems = await page.$$('[role="menu"] [role="menuitem"]');
-    for (const item of menuItems) {
-      const text = await item.evaluate(el => el.textContent);
-      if (text && text.includes('Admin Panel')) {
-        await item.click();
-        break;
-      }
-    }
-    
-    // Wait for navigation to complete
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
-    // Verify we're on the Super Admin page by checking URL
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    const superAdminUrl = await page.url();
-    expect(superAdminUrl).toContain('/admin');
-    
-    // Make sure sidebar is expanded by clicking the expand button if needed
-    const expandButton = await page.$('button[aria-label*="expand"], button[title*="expand"], .MuiDrawer-paper button');
-    if (expandButton) {
-      // Check if sidebar is collapsed by looking for collapsed class or narrow width
-      const isCollapsed = await page.evaluate(() => {
-        const drawer = document.querySelector('.MuiDrawer-paper');
-        return drawer && drawer.clientWidth < 100; // If width is very small, it's collapsed
-      });
-      
-      if (isCollapsed) {
-        await expandButton.click();
-        await new Promise(resolve => setTimeout(resolve, 500));
-      }
-    }
-    
-    // Find NEEMS header link to go back to main page
-    const neemsLinks = await page.$$('a[href="/"]');
-    let neemsLink = null;
-    
-    for (const link of neemsLinks) {
-      const text = await link.evaluate(el => el.textContent);
-      if (text && text.includes('NEEMS')) {
-        neemsLink = link;
-        break;
-      }
-    }
-    
-    // Only show debug output if the test is failing
-    if (!neemsLink) {
-      console.log('DEBUG: NEEMS link not found');
-      console.log(`Found ${neemsLinks.length} links with href="/"`);
-      
-      const allLinks = await page.$$('a');
-      console.log(`Total links found: ${allLinks.length}`);
-      for (let i = 0; i < Math.min(allLinks.length, 10); i++) {
-        const href = await allLinks[i].evaluate(el => el.getAttribute('href'));
-        const text = await allLinks[i].evaluate(el => el.textContent);
-        console.log(`Link ${i}: href="${href}", text="${text}"`);
-      }
-    }
-    
-    expect(neemsLink).not.toBeNull();
-    
-    // Verify the NEEMS link is functional by checking it has the correct href and is clickable
-    const href = await neemsLink!.evaluate(el => el.getAttribute('href'));
-    expect(href).toBe('/');
-    
-    // Test that the link is clickable (this validates the functionality works)
-    const isClickable = await neemsLink!.evaluate(el => {
-      // Check if the element is visible and has the correct properties
-      const rect = el.getBoundingClientRect();
-      return rect.width > 0 && rect.height > 0 && !el.hasAttribute('disabled');
+    await page.waitForSelector('#authed-ui-box', { timeout: 10000 });
+
+    // The logo link wraps a logo image and the "NEEMS" wordmark.
+    const href = await page.evaluate(() => {
+      const links = Array.from(document.querySelectorAll('a[href="/"]'));
+      const neems = links.find(a => /NEEMS/.test(a.textContent || ''));
+      return neems?.getAttribute('href') || null;
     });
-    expect(isClickable).toBe(true);
-    
-    // Note: Due to session management limitations in the test environment,
-    // we cannot reliably test the full navigation flow, but the NEEMS link
-    // is correctly implemented and functional in the application.
+    expect(href).toBe('/');
+  });
+
+  it('should navigate to /admin via the Admin Panel sidebar item', async () => {
+    // Start somewhere other than admin.
+    await page.goto(`${baseUrl}/scheduler`);
+    await loginAsSuperAdmin(page);
+    await page.waitForFunction(
+      () => document.body.innerText.includes('Schedule Calendar'),
+      { timeout: 10000 }
+    );
+
+    const clicked = await page.evaluate(() => {
+      const labels = Array.from(document.querySelectorAll('.MuiListItemText-primary'));
+      const adminLabel = labels.find(el => el.textContent === 'Admin Panel');
+      const button = adminLabel?.closest('[role="button"]') as HTMLElement | null;
+      if (button) {
+        button.click();
+        return true;
+      }
+      return false;
+    });
+    expect(clicked).toBe(true);
+    await new Promise(resolve => setTimeout(resolve, 1500));
+    expect(await page.url()).toContain('/admin');
+  });
+
+  it('should navigate via the primary sidebar items', async () => {
+    await loginAsSuperAdmin(page);
+    await page.waitForSelector('#authed-ui-box', { timeout: 10000 });
+
+    // Click the "Schedule" sidebar item.
+    const schedulerClicked = await page.evaluate(() => {
+      const labels = Array.from(document.querySelectorAll('.MuiListItemText-primary'));
+      const label = labels.find(el => el.textContent === 'Schedule');
+      const button = label?.closest('[role="button"]') as HTMLElement | null;
+      if (button) {
+        button.click();
+        return true;
+      }
+      return false;
+    });
+    expect(schedulerClicked).toBe(true);
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    expect(await page.url()).toContain('/scheduler');
+
+    // Then click "Single Line".
+    const sldClicked = await page.evaluate(() => {
+      const labels = Array.from(document.querySelectorAll('.MuiListItemText-primary'));
+      const label = labels.find(el => el.textContent === 'Single Line');
+      const button = label?.closest('[role="button"]') as HTMLElement | null;
+      if (button) {
+        button.click();
+        return true;
+      }
+      return false;
+    });
+    expect(sldClicked).toBe(true);
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    expect(await page.url()).toContain('/sld');
   });
 });

--- a/test/jest/tests/scheduler-page.test.ts
+++ b/test/jest/tests/scheduler-page.test.ts
@@ -1,0 +1,120 @@
+import {
+  navigateToApp,
+  loginAsSuperAdmin,
+  findButtonByText,
+} from './test-utils';
+
+describe('Scheduler Page Tests', () => {
+  const baseUrl = `http://localhost:${process.env.NEEMS_REACT_PORT || '5173'}`;
+
+  it('should navigate to start page and log in', async () => {
+    await navigateToApp(page);
+    await loginAsSuperAdmin(page);
+  });
+
+  it('should load the Scheduler page', async () => {
+    await page.goto(`${baseUrl}/scheduler`);
+    await page.waitForFunction(
+      () => document.body.innerText.includes('Schedule Calendar'),
+      { timeout: 10000 }
+    );
+    expect(await page.url()).toContain('/scheduler');
+  });
+
+  it('should render the calendar grid with weekday headers', async () => {
+    const content = await page.content();
+    for (const day of ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']) {
+      expect(content).toContain(day);
+    }
+  });
+
+  it('should display the current month name in the calendar header', async () => {
+    const monthName = new Date().toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+    const headerText = await page.evaluate(() => {
+      const headers = Array.from(document.querySelectorAll('h5')) as HTMLElement[];
+      return headers.find(h =>
+        /\b(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4}\b/
+          .test(h.textContent || '')
+      )?.textContent || null;
+    });
+    expect(headerText).toBe(monthName);
+  });
+
+  it('should advance the calendar a month and return via the Today button', async () => {
+    const today = new Date();
+    const nextMonth = new Date(today.getFullYear(), today.getMonth() + 1, 1);
+    const nextMonthName = nextMonth.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+    const currentMonthName = today.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+
+    // Locate the right-chevron icon button next to the calendar's month <h5>.
+    await page.evaluate(() => {
+      const headers = Array.from(document.querySelectorAll('h5')) as HTMLElement[];
+      const monthHeader = headers.find(h =>
+        /\b(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4}\b/
+          .test(h.textContent || '')
+      );
+      const parent = monthHeader?.parentElement;
+      const buttons = parent ? Array.from(parent.querySelectorAll('button')) : [];
+      const next = buttons.find(b => b.querySelector('svg[data-testid="ChevronRightIcon"]')) as HTMLElement | undefined;
+      next?.click();
+    });
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    const afterAdvance = await page.evaluate(() => {
+      const headers = Array.from(document.querySelectorAll('h5')) as HTMLElement[];
+      return headers.find(h =>
+        /\b(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4}\b/
+          .test(h.textContent || '')
+      )?.textContent || null;
+    });
+    expect(afterAdvance).toBe(nextMonthName);
+
+    const todayButton = await findButtonByText(page, ['Today']);
+    expect(await todayButton.evaluate((el: any) => !!el)).toBe(true);
+    await todayButton.click();
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    const afterToday = await page.evaluate(() => {
+      const headers = Array.from(document.querySelectorAll('h5')) as HTMLElement[];
+      return headers.find(h =>
+        /\b(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4}\b/
+          .test(h.textContent || '')
+      )?.textContent || null;
+    });
+    expect(afterToday).toBe(currentMonthName);
+  });
+
+  it('should open the day details modal when clicking a calendar date', async () => {
+    // Day cells are rendered as divs with a CSS-applied cursor:pointer and a
+    // direct child caption containing only a day number.
+    const clicked = await page.evaluate(() => {
+      const allDivs = Array.from(document.querySelectorAll('div')) as HTMLDivElement[];
+      const day15 = allDivs.find(d => {
+        if (window.getComputedStyle(d).cursor !== 'pointer') return false;
+        const caption = d.querySelector('.MuiTypography-caption');
+        return caption?.textContent?.trim() === '15';
+      });
+      if (day15) {
+        day15.click();
+        return true;
+      }
+      return false;
+    });
+    expect(clicked).toBe(true);
+    await page.waitForSelector('[role="dialog"]', { timeout: 5000 });
+
+    // Close the modal via Escape so subsequent steps see a clean state.
+    await page.keyboard.press('Escape');
+    await new Promise(resolve => setTimeout(resolve, 500));
+  });
+
+  it('should navigate to Library via the Manage Library button', async () => {
+    const manageLibraryButton = await findButtonByText(page, ['Manage Library']);
+    expect(await manageLibraryButton.evaluate((el: any) => !!el)).toBe(true);
+
+    await manageLibraryButton.click();
+    await new Promise(resolve => setTimeout(resolve, 1500));
+
+    expect(await page.url()).toContain('/library');
+  });
+});

--- a/test/jest/tests/sld-page.test.ts
+++ b/test/jest/tests/sld-page.test.ts
@@ -1,0 +1,96 @@
+import {
+  navigateToApp,
+  loginAsSuperAdmin,
+  findButtonByText,
+} from './test-utils';
+
+describe('SLD Page Tests', () => {
+  const baseUrl = `http://localhost:${process.env.NEEMS_REACT_PORT || '5173'}`;
+
+  it('should navigate to start page and log in', async () => {
+    // A larger viewport ensures the diagram lays out at a clickable size.
+    await page.setViewport({ width: 1600, height: 1200 });
+    await navigateToApp(page);
+    await loginAsSuperAdmin(page);
+  });
+
+  it('should land on the SLD page when navigating to root', async () => {
+    await page.goto(`${baseUrl}/`);
+    await page.waitForFunction(
+      () => document.body.innerText.includes('Single Line'),
+      { timeout: 20000 }
+    );
+    expect(await page.url()).toContain('/sld');
+  }, 30000);
+
+  it('should render the project info card', async () => {
+    const content = await page.content();
+    expect(content).toContain('Project Info: Brigis 1A');
+    expect(content).toContain('Address');
+    expect(content).toContain('BESS Rating');
+  });
+
+  it('should render the legend chips', async () => {
+    const chipLabels = await page.$$eval('.MuiChip-label', els =>
+      els.map(el => el.textContent || '')
+    );
+    expect(chipLabels).toContain('Normal');
+    expect(chipLabels).toContain('Warning');
+    expect(chipLabels).toContain('Critical');
+    expect(chipLabels).toContain('Emergency');
+  });
+
+  it('should render the E-Stop button inside the diagram', async () => {
+    // Wait for the diagram to mount and the EStopButton group to appear.
+    await page.waitForFunction(
+      () => {
+        const groups = Array.from(document.querySelectorAll('g')) as SVGGElement[];
+        return groups.some(g => {
+          const children = Array.from(g.children);
+          const hasEStopText = children.some(c => c.tagName.toLowerCase() === 'text' && c.textContent === 'E-STOP');
+          const hasBigCircle = children.some(c => c.tagName.toLowerCase() === 'circle' && c.getAttribute('r') === '44');
+          return hasEStopText && hasBigCircle;
+        });
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  it('should open the E-Stop confirmation dialog when clicked', async () => {
+    // Find the EStopButton g (one with E-STOP text and r=44 circle as direct children)
+    // and click via mouse coordinates from its bounding box.
+    const rect = await page.evaluate(() => {
+      const groups = Array.from(document.querySelectorAll('g')) as SVGGElement[];
+      const target = groups.find(g => {
+        const children = Array.from(g.children);
+        const hasEStopText = children.some(c => c.tagName.toLowerCase() === 'text' && c.textContent === 'E-STOP');
+        const hasBigCircle = children.some(c => c.tagName.toLowerCase() === 'circle' && c.getAttribute('r') === '44');
+        return hasEStopText && hasBigCircle;
+      });
+      if (!target) return null;
+      const r = target.getBoundingClientRect();
+      return { x: r.x, y: r.y, width: r.width, height: r.height };
+    });
+    expect(rect).not.toBeNull();
+
+    await page.mouse.click(rect!.x + rect!.width / 2, rect!.y + rect!.height / 2);
+    await page.waitForSelector('[role="dialog"]', { timeout: 5000 });
+
+    const dialogText = await page.$eval('[role="dialog"]', el => el.textContent || '');
+    expect(dialogText).toMatch(/Confirm E-Stop/i);
+  });
+
+  it('should dismiss the E-Stop dialog via Cancel without arming E-Stop', async () => {
+    const cancelButton = await findButtonByText(page, ['Cancel']);
+    expect(await cancelButton.evaluate((el: any) => !!el)).toBe(true);
+    await cancelButton.click();
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    const dialog = await page.$('[role="dialog"]');
+    expect(dialog).toBeNull();
+
+    // Confirm we did not arm E-Stop: the page should NOT show the active banner.
+    const content = await page.content();
+    expect(content).not.toContain('E-Stop is active.');
+  });
+});

--- a/test/jest/tests/static-and-api-servers-up.test.ts
+++ b/test/jest/tests/static-and-api-servers-up.test.ts
@@ -1,5 +1,5 @@
 import { navigateToApp } from './test-utils';
-import type { HealthStatus } from '../../../src/types/generated/HealthStatus';
+import type { HealthStatus } from '@newtown-energy/types';
 
 describe('NEEMS React App Tests', () => {
 

--- a/test/jest/tests/user-profile.test.ts
+++ b/test/jest/tests/user-profile.test.ts
@@ -1,138 +1,69 @@
-describe('User Profile Tests', () => {
+/**
+ * User profile / sidebar identity tests.
+ *
+ * The standalone UserProfile dropdown was consolidated into the sidebar
+ * (commit 934d7c9). The user's email is rendered inline in the sidebar header,
+ * Admin Panel and Logout are sidebar list items at the bottom.
+ */
+import {
+  navigateToApp,
+  loginAsSuperAdmin,
+} from './test-utils';
+
+const baseUrl = `http://localhost:${process.env.NEEMS_REACT_PORT || '5173'}`;
+
+describe('Sidebar User Identity Tests', () => {
   beforeEach(async () => {
-    // Clear cookies to ensure clean state between tests
     const client = await page.target().createCDPSession();
     await client.send('Network.clearBrowserCookies');
     await client.send('Network.clearBrowserCache');
     await client.detach();
-
-    await page.goto(`http://localhost:${process.env.NEEMS_REACT_PORT || '5173'}`);
+    // Sidebar auto-collapses below 900px wide and hides email + item labels.
+    await page.setViewport({ width: 1280, height: 800 });
+    await page.goto(baseUrl);
   });
 
-  it('should display user email and initial in UserProfile component after login', async () => {
-    let debugInfo: any = {};
-    
-    try {
-      // Login first
-      await page.waitForSelector('input[type="email"]');
-      await page.type('input[type="email"]', 'superadmin@example.com');
-      await page.type('input[type="password"]', 'admin');
-      await page.click('button[type="submit"]');
-      
-      // Wait for login to complete and page to load
-      await new Promise(resolve => setTimeout(resolve, 3000));
-      
-      // Wait for UserProfile component to be present
-      await page.waitForSelector('[data-testid="user-profile"]', { timeout: 10000 });
-      
-      // Verify localStorage has the email (debug step)
-      const storedEmail = await page.evaluate(() => localStorage.getItem('userEmail'));
-      debugInfo.storedEmail = storedEmail;
-      
-      // Check what the component is currently showing
-      const currentEmailText = await page.$eval('[data-testid="user-profile"] .MuiTypography-root', el => el.textContent);
-      debugInfo.currentEmailText = currentEmailText;
-      
-      // If the email isn't showing correctly, try reloading to trigger useEffect
-      if (currentEmailText === 'Unknown User' && storedEmail) {
-        debugInfo.reloadTriggered = true;
-        await page.reload();
-        await new Promise(resolve => setTimeout(resolve, 3000));
-        await page.waitForSelector('[data-testid="user-profile"]', { timeout: 5000 });
+  it('should display the logged-in user email in the sidebar', async () => {
+    await loginAsSuperAdmin(page);
+
+    // Sidebar shows the user's email under the NEEMS header.
+    await page.waitForFunction(
+      () => document.body.innerText.includes('superadmin@example.com'),
+      { timeout: 10000 }
+    );
+  });
+
+  it('should expose an Admin Panel sidebar item for super admins', async () => {
+    await loginAsSuperAdmin(page);
+    await page.waitForSelector('#authed-ui-box', { timeout: 10000 });
+
+    const adminItemPresent = await page.evaluate(() => {
+      const items = Array.from(document.querySelectorAll('.MuiListItemText-primary'));
+      return items.some(el => el.textContent === 'Admin Panel');
+    });
+    expect(adminItemPresent).toBe(true);
+  });
+
+  it('should log out via the sidebar Logout item', async () => {
+    await loginAsSuperAdmin(page);
+    await page.waitForSelector('#authed-ui-box', { timeout: 10000 });
+
+    // Click the Logout sidebar item by matching its text.
+    const clicked = await page.evaluate(() => {
+      const labels = Array.from(document.querySelectorAll('.MuiListItemText-primary'));
+      const logoutLabel = labels.find(el => el.textContent === 'Logout');
+      const button = logoutLabel?.closest('[role="button"]') as HTMLElement | null;
+      if (button) {
+        button.click();
+        return true;
       }
-      
-      // Check that the email is displayed
-      const emailText = await page.$eval('[data-testid="user-profile"] .MuiTypography-root', el => el.textContent);
-      debugInfo.finalEmailText = emailText;
-      expect(emailText).toBe('superadmin@example.com');
-      
-      // Check that the avatar contains the correct initial
-      const avatarText = await page.$eval('[data-testid="user-profile"] .MuiAvatar-root', el => el.textContent);
-      expect(avatarText).toBe('S');
-    } catch (error) {
-      // Only log debug info on failure
-      console.log('Test failed. Debug info:', debugInfo);
-      throw error;
-    }
-  });
+      return false;
+    });
+    expect(clicked).toBe(true);
 
-  it('should show fallback text when no email is available', async () => {
-    // Login first
-    await page.waitForSelector('input[type="email"]');
-    await page.type('input[type="email"]', 'superadmin@example.com');
-    await page.type('input[type="password"]', 'admin');
-    await page.click('button[type="submit"]');
-    
-    // Wait for login to complete
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
-    // Clear localStorage to simulate missing email
-    await page.evaluate(() => localStorage.clear());
-    await page.reload();
-    
-    // Wait for page to load
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    
-    // Check for fallback text (if still authenticated but no email stored)
+    // Logout reloads the page and returns to the login form.
+    await page.waitForSelector('input[type="email"]', { timeout: 10000 });
     const content = await page.content();
-    if (content.includes('Unknown User')) {
-      const emailText = await page.$eval('[data-testid="user-profile"] .MuiTypography-root', el => el.textContent);
-      expect(emailText).toBe('Unknown User');
-    }
+    expect(content).toMatch('NEEMS Login');
   });
-
-  it('should show dropdown menu when clicking on user profile and allow logout', async () => {
-    // Login first
-    await page.waitForSelector('input[type="email"]');
-    await page.type('input[type="email"]', 'superadmin@example.com');
-    await page.type('input[type="password"]', 'admin');
-    await page.click('button[type="submit"]');
-    
-    // Wait for login to complete and page to load
-    await new Promise(resolve => setTimeout(resolve, 3000));
-    
-    // Wait for UserProfile component to be present
-    await page.waitForSelector('[data-testid="user-profile"]', { timeout: 10000 });
-    
-    // Click on the user profile to open dropdown
-    await page.click('[data-testid="user-profile"]');
-    
-    // Wait for menu to appear
-    await new Promise(resolve => setTimeout(resolve, 500));
-    
-    // Check that the menu is visible and contains expected items
-    await page.waitForSelector('[role="menu"]', { timeout: 5000 });
-    
-    // Verify company name is displayed in the dropdown
-    const menuContent = await page.$eval('[role="menu"]', el => el.textContent);
-    expect(menuContent).toContain('Newtown Energy'); // Default company name
-    
-    // Verify admin menu items are present (superadmin@example.com has newtown-admin role)
-    expect(menuContent).toContain('Admin Panel');
-    expect(menuContent).toContain('Logout');
-    
-    // Test logout functionality - find and click the logout menu item
-    const logoutMenuItems = await page.$$('[role="menu"] [role="menuitem"]');
-    let logoutMenuItem = null;
-    
-    for (const item of logoutMenuItems) {
-      const text = await item.evaluate(el => el.textContent);
-      if (text && text.includes('Logout')) {
-        logoutMenuItem = item;
-        break;
-      }
-    }
-    
-    expect(logoutMenuItem).not.toBeNull();
-    await logoutMenuItem!.click();
-    
-    // Wait for logout to complete and redirect to login page
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
-    // Verify we're back on the login page
-    await page.waitForSelector('input[type="email"]', { timeout: 5000 });
-    const loginPageContent = await page.content();
-    expect(loginPageContent).toMatch('NEEMS Login');
-  });
-
 });


### PR DESCRIPTION
## Summary

- Adds 26 E2E tests across 4 new files covering `SchedulerPage`, `LibraryPage`, `AlarmsPage`, and `SldPage` — closes #51.
- Each page exercises a real interaction (month navigation + Today reset, dialog open/close, severity filter toggle, E-Stop confirm flow) rather than just smoke-checking the heading.
- Repairs three pre-existing E2E failures unrelated to #51 but uncovered while running the suite: stale `HealthStatus` import path and the legacy `UserProfile` dropdown which has been consolidated into `Sidebar`.
- Adds a `tsc-tests` CI job so the Jest test files no longer bitrot. Running the E2E suite itself in CI is a meaningfully bigger infra task tracked in #69.
- Filed #68 to evaluate Playwright as a replacement / complement to the current Puppeteer setup.

## Test plan

- [x] Each new test file passes locally in isolation
- [x] All 11 test suites pass when run in parallel via `npx jest --config=test/jest/tests/jest.config.js`
- [x] `tsc --noEmit -p test/jest/tsconfig.json` passes locally
- [ ] CI `tsc-tests` job passes on this PR
- [ ] Manual smoke against a deployed branch preview (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)