### PR TITLE
Extract role-check helpers (closes #50)

### DIFF
--- a/src/components/CompanySelector/CompanySelector.tsx
+++ b/src/components/CompanySelector/CompanySelector.tsx
@@ -11,6 +11,7 @@ import { Business } from '@mui/icons-material';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { apiRequestWithMapping } from '../../utils/api';
 import type { Company } from '@newtown-energy/types';
+import { isSuperAdmin } from '../../utils/auth';
 import { debugLog, errorLog } from '../../utils/debug';
 
 interface CompanySelectorProps {
@@ -30,13 +31,13 @@ export const CompanySelector: React.FC<CompanySelectorProps> = ({
   const navigate = useNavigate();
   const location = useLocation();
 
-  const isSuperAdmin = userRoles.includes('newtown-admin') || userRoles.includes('newtown-staff');
+  const userIsSuperAdmin = isSuperAdmin(userRoles);
 
   useEffect(() => {
-    if (isSuperAdmin) {
+    if (userIsSuperAdmin) {
       fetchCompanies();
     }
-  }, [isSuperAdmin]);
+  }, [userIsSuperAdmin]);
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -115,7 +116,7 @@ export const CompanySelector: React.FC<CompanySelectorProps> = ({
     }
   };
 
-  if (!isSuperAdmin) {
+  if (!userIsSuperAdmin) {
     return null;
   }
 

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -6,6 +6,7 @@ import { SidebarItem } from './SidebarItem';
 import { getPageConfig } from '../../config/pageRegistry';
 import { CompanySelector } from '../CompanySelector/CompanySelector';
 import { useAuth } from '../../pages/LoginPage/useAuth';
+import { isAdmin } from '../../utils/auth';
 import { debugLog, errorLog } from '../../utils/debug';
 
 interface SidebarProps {
@@ -28,8 +29,7 @@ const Sidebar: React.FC<SidebarProps> = () => { // Removed unused className
     return 'sld';
   };
 
-  const userRoles = userInfo?.roles || [];
-  const isAdmin = userRoles.includes('admin') || userRoles.includes('newtown-admin') || userRoles.includes('newtown-staff');
+  const showAdminPanel = isAdmin(userInfo?.roles);
 
   // Stripped dev-target menu (SLD feedback round). The Overview deep-link route
   // still exists in App.tsx but is no longer in the sidebar.
@@ -48,7 +48,7 @@ const Sidebar: React.FC<SidebarProps> = () => { // Removed unused className
   }).filter((item): item is NonNullable<typeof item> => item !== null);
 
   const bottomItems = [
-    ...(isAdmin ? [{ id: 'admin', icon: AdminPanelSettings, text: 'Admin Panel' }] : []),
+    ...(showAdminPanel ? [{ id: 'admin', icon: AdminPanelSettings, text: 'Admin Panel' }] : []),
     { id: 'help', icon: Help, text: 'Ask for help' },
     { id: 'logout', icon: Logout, text: 'Logout' }
   ];

--- a/src/components/UserProfile/UserProfile.tsx
+++ b/src/components/UserProfile/UserProfile.tsx
@@ -3,6 +3,7 @@ import { Box, Typography, Avatar, Menu, MenuItem, Divider, ListItemIcon } from '
 import { AdminPanelSettings, Logout } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import type { UserInfo } from '../../types/auth';
+import { isAdmin } from '../../utils/auth';
 
 interface UserProfileProps {
   email: string;
@@ -40,9 +41,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
     return email.charAt(0).toUpperCase();
   };
 
-  // Extract roles from userInfo, with fallback to empty array
-  const userRoles = userInfo?.roles || [];
-  const isAdmin = userRoles.includes('admin') || userRoles.includes('newtown-admin') || userRoles.includes('newtown-staff');
+  const showAdminPanel = isAdmin(userInfo?.roles);
 
   return (
     <>
@@ -87,7 +86,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
           </>
         )}
         
-        {isAdmin && (
+        {showAdminPanel && (
           <MenuItem onClick={handleAdminPanel}>
             <ListItemIcon>
               <AdminPanelSettings fontSize="small" />
@@ -95,8 +94,8 @@ const UserProfile: React.FC<UserProfileProps> = ({
             Admin Panel
           </MenuItem>
         )}
-        
-        {isAdmin && <Divider />}
+
+        {showAdminPanel && <Divider />}
         
         <MenuItem onClick={handleLogout}>
           <ListItemIcon>

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -35,6 +35,7 @@ import { useSearchParams } from 'react-router-dom';
 import type { Company, Site, CompanyWithTimestamps, UserWithRolesAndTimestamps, CreateUserWithRolesRequest, UpdateUserRequest, CreateSiteRequest } from '@newtown-energy/types';
 import { apiRequestWithMapping, ApiError } from '../utils/api';
 import type { ODataQueryOptions } from '../utils/api';
+import { isAdmin, isSuperAdmin } from '../utils/auth';
 import { debugLog, errorLog } from '../utils/debug';
 
 type UserWithExpandedCompany = UserWithRolesAndTimestamps & { Company?: Company };
@@ -92,10 +93,8 @@ const AdminPage: React.FC = () => {
   const [companyToDelete, setCompanyToDelete] = useState<CompanyWithTimestamps | null>(null);
   const [companyModalError, setCompanyModalError] = useState<string | null>(null);
 
-  // Role checks
-  const currentUserRoles = userInfo?.roles || [];
-  const isAdmin = currentUserRoles.includes('admin') || currentUserRoles.includes('newtown-admin');
-  const isSuperAdmin = currentUserRoles.includes('newtown-admin') || currentUserRoles.includes('newtown-staff');
+  const userIsAdmin = isAdmin(userInfo?.roles);
+  const userIsSuperAdmin = isSuperAdmin(userInfo?.roles);
 
   // Available roles based on company
   const getAvailableRoles = (companyId: number): string[] => {
@@ -109,10 +108,10 @@ const AdminPage: React.FC = () => {
   };
 
   useEffect(() => {
-    if (isAdmin) {
+    if (userIsAdmin) {
       fetchCompanies();
     }
-  }, [isAdmin]);
+  }, [userIsAdmin]);
 
   useEffect(() => {
     // Load users and sites when selectedCompanyId changes
@@ -541,7 +540,7 @@ const AdminPage: React.FC = () => {
     }
   };
 
-  if (!isAdmin) {
+  if (!userIsAdmin) {
     return (
       <Box sx={{ p: 3 }}>
         <Typography variant="h2" gutterBottom>
@@ -587,7 +586,7 @@ const AdminPage: React.FC = () => {
             <Tabs value={tabValue} onChange={(_, newValue) => setTabValue(newValue)}>
               <Tab icon={<Person />} label="Users" />
               <Tab icon={<LocationOn />} label="Sites" />
-              {isSuperAdmin && (
+              {userIsSuperAdmin && (
                 <Tab icon={<Business />} label="COMPANIES" />
               )}
             </Tabs>
@@ -795,7 +794,7 @@ const AdminPage: React.FC = () => {
       )}
 
       {/* Companies Tab - Only for Super Admins */}
-      {tabValue === 2 && isSuperAdmin && (
+      {tabValue === 2 && userIsSuperAdmin && (
         <Card>
           <CardContent>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,12 @@
+export const isAdmin = (roles: readonly string[] | undefined | null): boolean =>
+  !!roles && (
+    roles.includes('admin') ||
+    roles.includes('newtown-admin') ||
+    roles.includes('newtown-staff')
+  );
+
+export const isSuperAdmin = (roles: readonly string[] | undefined | null): boolean =>
+  !!roles && (
+    roles.includes('newtown-admin') ||
+    roles.includes('newtown-staff')
+  );


### PR DESCRIPTION
Closes #50.

## Summary
- Add `src/utils/auth.ts` with `isAdmin(roles)` and `isSuperAdmin(roles)`
- Route the four duplicated inline role checks (Sidebar, UserProfile, AdminPage, CompanySelector) through the helpers

## Behavior change
The four call sites had drifted into two definitions of `isAdmin`:
- Sidebar / UserProfile: `admin` + `newtown-admin` + `newtown-staff`
- AdminPage: `admin` + `newtown-admin` (no newtown-staff)

Consolidated to the 3-role definition (the pattern called out in the issue body). newtown-staff users will now reach `AdminPage` instead of hitting "Access denied" — this resolves a prior inconsistency where Sidebar already showed them an Admin Panel link that landed on the denied page. `isSuperAdmin` (newtown-admin + newtown-staff) was already consistent and is unchanged.

## Test plan
- [x] `bun run lint:tsc` passes
- [x] `bun run lint:eslint` passes
- [ ] Smoke check: log in as each role and confirm Admin Panel visibility/access matches the new policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)