### PR TITLE
Standardize on apiRequestWithMapping; remove dead helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,11 +164,11 @@ neems-react/
 
 ### API Client (`src/utils/api.ts`)
 
-The project uses a centralized API client with these key functions:
+The project uses a centralized API client. **Use `apiRequestWithMapping` for all API calls** — it is the standard helper and handles every endpoint pattern in the codebase.
 
-1. **`apiRequest<T>(url, options)`** - Basic API request with JSON parsing and error handling
-2. **`apiRequestOData<T>(url, options, queryOptions)`** - OData-aware requests that unwrap collections
-3. **`apiRequestWithMapping<T>(url, options, queryOptions)`** - Maps legacy endpoints to new OData endpoints
+- **`apiRequestWithMapping<T>(url, options, queryOptions)`** — Standard helper. Maps legacy lowercase endpoints (e.g. `/api/1/users`) to OData equivalents (`/api/1/Users`) and unwraps OData collection envelopes for GET requests automatically. Falls through to the basic request behavior for non-collection endpoints (auth, alarms, etc.), so it is safe for everything.
+- **`apiRequest<T>(url, options)`** — Lower-level: raw fetch with JSON parsing and error handling. Use only if you specifically need to bypass URL mapping and OData unwrapping.
+- **`apiRequestOData<T>(url, options, queryOptions)`** — Lower-level: returns `{ data, count }` for collection endpoints. Use only when you need the OData `@odata.count` alongside the data.
 
 ### OData Support
 

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Box, Button, TextField, Typography, Paper } from "@mui/material";
 import type { LoginSuccessResponse } from "../../types/auth";
-import { apiRequest, ApiError } from "../../utils/api";
+import { apiRequestWithMapping, ApiError } from "../../utils/api";
 import { debugLog } from "../../utils/debug";
 
 type Props = { onLoginSuccess: (userInfo: LoginSuccessResponse) => void };
@@ -21,7 +21,7 @@ const LoginPage: React.FC<Props> = ({ onLoginSuccess }) => {
     debugLog('LoginPage: Login attempt', { email });
 
     try {
-      const userInfo = await apiRequest<LoginSuccessResponse>("/api/1/login", {
+      const userInfo = await apiRequestWithMapping<LoginSuccessResponse>("/api/1/login", {
         method: "POST",
         body: JSON.stringify(requestBody),
       });

--- a/src/pages/LoginPage/useAuth.ts
+++ b/src/pages/LoginPage/useAuth.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import type { LoginSuccessResponse } from "../../types/auth";
-import { apiRequest, ApiError } from "../../utils/api";
+import { apiRequestWithMapping, ApiError } from "../../utils/api";
 import { debugLog, errorLog } from "../../utils/debug";
 
 export function useAuth() {
@@ -51,7 +51,7 @@ export function useAuth() {
     }
 
     debugLog('useAuth: Calling /api/1/hello to verify authentication');
-    apiRequest<LoginSuccessResponse>('/api/1/hello')
+    apiRequestWithMapping<LoginSuccessResponse>('/api/1/hello')
       .then((data) => {
         debugLog('useAuth: Authentication verified', { email: data.email, roles: data.roles });
         setIsAuthenticated(true);
@@ -77,7 +77,7 @@ export function useAuth() {
   const logout = async () => {
     debugLog('useAuth: Logout initiated');
     try {
-      await apiRequest('/api/1/logout', {
+      await apiRequestWithMapping('/api/1/logout', {
         method: 'POST'
       });
       debugLog('useAuth: Logout API call successful');

--- a/src/utils/alarmApi.ts
+++ b/src/utils/alarmApi.ts
@@ -3,14 +3,14 @@ import type {
   AlarmDefinitionsResponse,
   AlarmHistoryResponse,
 } from '@newtown-energy/types';
-import { apiRequest } from './api';
+import { apiRequestWithMapping } from './api';
 
 export async function fetchActiveAlarms(): Promise<ActiveAlarmsResponse> {
-  return await apiRequest<ActiveAlarmsResponse>('/api/1/Alarms/Active');
+  return await apiRequestWithMapping<ActiveAlarmsResponse>('/api/1/Alarms/Active');
 }
 
 export async function fetchAlarmDefinitions(): Promise<AlarmDefinitionsResponse> {
-  return await apiRequest<AlarmDefinitionsResponse>('/api/1/Alarms/Definitions');
+  return await apiRequestWithMapping<AlarmDefinitionsResponse>('/api/1/Alarms/Definitions');
 }
 
 /**
@@ -29,5 +29,5 @@ export async function fetchAlarmHistory(
   if (alarmNums && alarmNums.length > 0) {
     params.set('alarm_nums', alarmNums.join(','));
   }
-  return await apiRequest<AlarmHistoryResponse>(`/api/1/Alarms/History?${params.toString()}`);
+  return await apiRequestWithMapping<AlarmHistoryResponse>(`/api/1/Alarms/History?${params.toString()}`);
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -51,6 +51,13 @@ function buildODataQuery(options: ODataQueryOptions): string {
   return queryString ? `?${queryString}` : '';
 }
 
+/**
+ * Low-level API request helper. Most callers should prefer `apiRequestWithMapping`,
+ * which adds endpoint mapping and OData-collection unwrapping on top of this.
+ *
+ * Use this directly only when you need the raw fetch behavior without any
+ * URL rewriting or collection-envelope handling.
+ */
 export async function apiRequest<T = unknown>(
   url: string,
   options: RequestInit = {}
@@ -133,7 +140,12 @@ export async function apiRequest<T = unknown>(
   }
 }
 
-// OData-aware API request for collections (automatically unwraps OData envelope)
+/**
+ * OData-aware request for collection endpoints; returns the unwrapped `value`
+ * array plus the optional `@odata.count`. Most callers should prefer
+ * `apiRequestWithMapping`, which delegates here automatically for collection
+ * endpoints. Use this directly only when you need the count alongside the data.
+ */
 export async function apiRequestOData<T = unknown>(
   url: string,
   options: RequestInit = {},
@@ -237,7 +249,12 @@ function mapNavigationEndpoint(url: string): string {
   return url;
 }
 
-// Enhanced API request that automatically maps old endpoints to new OData endpoints
+/**
+ * Standard API helper: maps legacy lowercase endpoints (e.g. `/api/1/users`)
+ * to their OData equivalents (`/api/1/Users`) and unwraps OData collection
+ * envelopes for GET requests automatically. Prefer this over the lower-level
+ * `apiRequest` / `apiRequestOData` for new code.
+ */
 export async function apiRequestWithMapping<T = unknown>(
   url: string,
   options: RequestInit = {},
@@ -261,26 +278,6 @@ export async function apiRequestWithMapping<T = unknown>(
   const queryString = queryOptions ? buildODataQuery(queryOptions) : '';
   const fullUrl = `${mappedUrl}${queryString}`;
   return await apiRequest<T>(fullUrl, options);
-}
-
-// Convenience function for getting OData collections with count information
-export async function apiRequestODataWithCount<T = unknown>(
-  url: string,
-  options: RequestInit = {},
-  queryOptions?: ODataQueryOptions
-): Promise<{ data: T[]; count?: number; hasMore?: boolean }> {
-  const result = await apiRequestOData<T>(url, options, queryOptions);
-  
-  // Calculate if there are more records (useful for pagination)
-  const hasMore = queryOptions?.$top && result.count 
-    ? (queryOptions.$skip || 0) + queryOptions.$top < result.count
-    : undefined;
-    
-  return {
-    data: result.data,
-    count: result.count,
-    hasMore
-  };
 }
 
 export { ApiError };


### PR DESCRIPTION
Closes #49.

## Summary
- Deleted `apiRequestODataWithCount` (0 callers — dead export).
- Migrated the six remaining `apiRequest` callers (alarms x3, login, hello, logout) to `apiRequestWithMapping` so callers go through a single helper. Behavior is identical: these endpoints don't match the OData collection regexes, so `apiRequestWithMapping` falls through to the same `apiRequest` code path internally.
- Added JSDoc to `api.ts` and updated `AGENTS.md` (source of the symlinked `CLAUDE.md`) to mark `apiRequestWithMapping` as the standard helper and document when the lower-level `apiRequest` / `apiRequestOData` helpers are appropriate (escape hatches: bypass URL mapping, or get `@odata.count`).

## Test plan
- [x] \`bun run lint:tsc\` passes
- [x] \`bun run lint:eslint\` passes
- [x] \`bun run build\` succeeds
- [ ] Smoke-test login, hello (auth check on load), logout, and the alarms page in a running dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)