### PR TITLE
Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to keep GitHub Actions versions current via weekly Dependabot PRs
- Scope intentionally limited to `github-actions` per #11; npm updates deferred until CI test coverage is more robust

Closes #11

## Test plan
- [ ] Merge and confirm Dependabot picks up the config (Insights -> Dependency graph -> Dependabot)
- [ ] Verify a weekly run opens PRs for any outdated actions in `.github/workflows/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)