### PR TITLE
Demo UX: schedule now-marker, SoC range/axis, FDNY legibility, legend, create-reason

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "recharts": "^3.8.1",
       },
       "devDependencies": {
-        "@newtown-energy/types": "0.3.2",
+        "@newtown-energy/types": "0.3.3",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.0.10",
         "@types/react": "^19.1.8",
@@ -331,7 +331,7 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
-    "@newtown-energy/types": ["@newtown-energy/types@0.3.2", "https://npm.pkg.github.com/download/@newtown-energy/types/0.3.2/1ed4f04f0752c96b872a77b57eb2ec47c78f15ea", {}, "sha512-NyNBo4dG6N9vFjhED5ZRxDwaStfuL5/yKirhA0ecQJsHSNfJDMYNfKOLwvrnW/gczvLC50AEIaWwt0pIhvS7dQ=="],
+    "@newtown-energy/types": ["@newtown-energy/types@0.3.3", "https://npm.pkg.github.com/download/@newtown-energy/types/0.3.3/ddd72d7bb3c9d98ac9d3fb84586d376ce49fa14b", {}, "sha512-SF9gYXPLxj/49/FYORKsHgy1xHuF/Sjtrrh+pTozpWUYJe9++f8rt8EqVbDT4YwgkqRvyxbVWs4zMKr3BPd7rQ=="],
 
     "@parcel/watcher": ["@parcel/watcher@2.5.6", "", { "dependencies": { "detect-libc": "^2.0.3", "is-glob": "^4.0.3", "node-addon-api": "^7.0.0", "picomatch": "^4.0.3" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.6", "@parcel/watcher-darwin-arm64": "2.5.6", "@parcel/watcher-darwin-x64": "2.5.6", "@parcel/watcher-freebsd-x64": "2.5.6", "@parcel/watcher-linux-arm-glibc": "2.5.6", "@parcel/watcher-linux-arm-musl": "2.5.6", "@parcel/watcher-linux-arm64-glibc": "2.5.6", "@parcel/watcher-linux-arm64-musl": "2.5.6", "@parcel/watcher-linux-x64-glibc": "2.5.6", "@parcel/watcher-linux-x64-musl": "2.5.6", "@parcel/watcher-win32-arm64": "2.5.6", "@parcel/watcher-win32-ia32": "2.5.6", "@parcel/watcher-win32-x64": "2.5.6" } }, "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "recharts": "^3.8.1"
   },
   "devDependencies": {
-    "@newtown-energy/types": "0.3.2",
+    "@newtown-energy/types": "0.3.3",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.0.10",
     "@types/react": "^19.1.8",

--- a/src/components/CommandCalendar/CommandCalendar.tsx
+++ b/src/components/CommandCalendar/CommandCalendar.tsx
@@ -36,6 +36,7 @@ import { toISODateString } from '../../utils/scheduleHelpers';
 import { debugLog, errorLog } from '../../utils/debug';
 import { useSiteContext } from '../../utils/SiteContext';
 import CalendarGrid, { getWeekCount, getWeekIndexForDate } from './CalendarGrid';
+import ScheduleLegend from './ScheduleLegend';
 import DayDetailsDialog from './DayDetailsDialog';
 import type { ApplicableLibraryItem } from './DayDetailsDialog';
 import OverrideReasonDialog from './OverrideReasonDialog';
@@ -427,6 +428,7 @@ const CommandCalendar: React.FC<CommandCalendarProps> = ({
           viewMode={viewMode}
           weekIndex={weekIndex}
         />
+        <ScheduleLegend />
       </Box>
 
       <DayDetailsDialog

--- a/src/components/CommandCalendar/DayBarChart.tsx
+++ b/src/components/CommandCalendar/DayBarChart.tsx
@@ -37,8 +37,9 @@ interface DayBarChartProps {
   height?: number;
   /**
    * Seconds-since-midnight of the effective "now" (real wall-clock or the
-   * demo-overrides forced clock). When non-null, a vertical playhead line
-   * is drawn at that offset. Pass null for non-today cells.
+   * demo-overrides forced clock). When non-null, a circular playhead marker
+   * is drawn at that offset, centered on the axis. Pass null for non-today
+   * cells.
    */
   nowSeconds?: number | null;
 }
@@ -113,54 +114,65 @@ const DayBarChart: React.FC<DayBarChartProps> = ({
       ? (nowSeconds / TOTAL_SECONDS) * 100
       : null;
 
+  // The now marker is an HTML overlay rather than an SVG element: the chart
+  // uses preserveAspectRatio="none", which would squash a <circle> into an
+  // ellipse. A positioned <span> stays perfectly round at any cell width.
+  const nowMarkerSize = Math.max(6, Math.min(height / 3, 10));
+
   return (
-    <svg
-      viewBox={`0 0 100 ${height}`}
-      width="100%"
-      height={height}
-      preserveAspectRatio="none"
-      style={{ display: 'block' }}
-      role="img"
-      aria-label="Charge/discharge schedule for this day"
-    >
-      <line x1={0} x2={100} y1={axisY} y2={axisY} stroke="#bdbdbd" strokeWidth={0.5} />
-      {commands.map(cmd => {
-        const bar = commandBar(cmd, { axisY, maxBarHeight, chargeFraction, dischargeFraction });
-        if (!bar) return null;
-        const power = sitePowerKw ? ` @ ~${Math.round(sitePowerKw)} kW` : '';
-        const endSeconds = Math.min(
-          TOTAL_SECONDS,
-          cmd.execution_offset_seconds + (cmd.duration_seconds ?? 0)
-        );
-        const tooltip = `${cmd.command_type.replace('_', ' ')} ${secondsToTime(cmd.execution_offset_seconds)}–${secondsToTime(endSeconds)}${power}`;
-        return (
-          <rect
-            key={cmd.id}
-            x={bar.x}
-            y={bar.y}
-            width={bar.width}
-            height={bar.height}
-            fill={bar.fill}
-            opacity={0.85}
-          >
-            <title>{tooltip}</title>
-          </rect>
-        );
-      })}
+    <div style={{ position: 'relative', width: '100%', height, lineHeight: 0 }}>
+      <svg
+        viewBox={`0 0 100 ${height}`}
+        width="100%"
+        height={height}
+        preserveAspectRatio="none"
+        style={{ display: 'block' }}
+        role="img"
+        aria-label="Charge/discharge schedule for this day"
+      >
+        <line x1={0} x2={100} y1={axisY} y2={axisY} stroke="#bdbdbd" strokeWidth={0.5} />
+        {commands.map(cmd => {
+          const bar = commandBar(cmd, { axisY, maxBarHeight, chargeFraction, dischargeFraction });
+          if (!bar) return null;
+          const power = sitePowerKw ? ` @ ~${Math.round(sitePowerKw)} kW` : '';
+          const endSeconds = Math.min(
+            TOTAL_SECONDS,
+            cmd.execution_offset_seconds + (cmd.duration_seconds ?? 0)
+          );
+          const tooltip = `${cmd.command_type.replace('_', ' ')} ${secondsToTime(cmd.execution_offset_seconds)}–${secondsToTime(endSeconds)}${power}`;
+          return (
+            <rect
+              key={cmd.id}
+              x={bar.x}
+              y={bar.y}
+              width={bar.width}
+              height={bar.height}
+              fill={bar.fill}
+              opacity={0.85}
+            >
+              <title>{tooltip}</title>
+            </rect>
+          );
+        })}
+      </svg>
       {nowX != null && (
-        <line
-          x1={nowX}
-          x2={nowX}
-          y1={0}
-          y2={height}
-          stroke="#d32f2f"
-          strokeWidth={0.75}
-          opacity={0.85}
-        >
-          <title>{`Now: ${secondsToTime(nowSeconds ?? 0)}`}</title>
-        </line>
+        <span
+          title={`Now: ${secondsToTime(nowSeconds ?? 0)}`}
+          style={{
+            position: 'absolute',
+            left: `${nowX}%`,
+            top: '50%',
+            transform: 'translate(-50%, -50%)',
+            width: nowMarkerSize,
+            height: nowMarkerSize,
+            borderRadius: '50%',
+            backgroundColor: '#424242',
+            opacity: 0.85,
+            pointerEvents: 'auto'
+          }}
+        />
       )}
-    </svg>
+    </div>
   );
 };
 

--- a/src/components/CommandCalendar/ScheduleLegend.tsx
+++ b/src/components/CommandCalendar/ScheduleLegend.tsx
@@ -1,0 +1,39 @@
+/**
+ * Color key for the charge/discharge/trickle bars drawn in each calendar
+ * day cell (see DayBarChart). Rendered directly beneath the schedule
+ * calendar so the legend sits next to the thing it explains.
+ */
+
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+
+import { COMMAND_BAR_COLORS } from '../../utils/scheduleHelpers';
+
+const LEGEND_ENTRIES = [
+  { color: COMMAND_BAR_COLORS.charge, label: 'Charge' },
+  { color: COMMAND_BAR_COLORS.discharge, label: 'Discharge' },
+  { color: COMMAND_BAR_COLORS.trickle_charge, label: 'Trickle' },
+] as const;
+
+const ScheduleLegend: React.FC = () => (
+  <Box
+    sx={{
+      display: 'flex',
+      gap: 2,
+      justifyContent: 'center',
+      flexWrap: 'wrap',
+      py: 1,
+    }}
+  >
+    {LEGEND_ENTRIES.map(({ color, label }) => (
+      <Box key={label} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+        <Box sx={{ width: 10, height: 10, borderRadius: '50%', bgcolor: color, flexShrink: 0 }} />
+        <Typography variant="caption" color="text.secondary" noWrap>
+          {label}
+        </Typography>
+      </Box>
+    ))}
+  </Box>
+);
+
+export default ScheduleLegend;

--- a/src/components/ScheduleLibrary/CreateScheduleDialog.tsx
+++ b/src/components/ScheduleLibrary/CreateScheduleDialog.tsx
@@ -17,7 +17,10 @@ import CommandsTable from './CommandsTable';
 interface CreateScheduleDialogProps {
   open: boolean;
   onClose: () => void;
-  onCreate: (data: { name: string; description: string | null; commands: ScheduleCommandDto[] }) => Promise<void>;
+  onCreate: (
+    data: { name: string; description: string | null; commands: ScheduleCommandDto[] },
+    changeReason: string,
+  ) => Promise<void>;
   onError?: (message: string) => void;
 }
 
@@ -30,6 +33,8 @@ const CreateScheduleDialog: React.FC<CreateScheduleDialogProps> = ({
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [commands, setCommands] = useState<ScheduleCommandDto[]>([]);
+  // Required so every new schedule lands in the change history with a why.
+  const [changeReason, setChangeReason] = useState('');
   const [commandDialogOpen, setCommandDialogOpen] = useState(false);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
 
@@ -38,6 +43,7 @@ const CreateScheduleDialog: React.FC<CreateScheduleDialogProps> = ({
       setName('');
       setDescription('');
       setCommands([]);
+      setChangeReason('');
     }
   }, [open]);
 
@@ -73,11 +79,18 @@ const CreateScheduleDialog: React.FC<CreateScheduleDialogProps> = ({
       onError?.('Name is required');
       return;
     }
-    await onCreate({
-      name: name.trim(),
-      description: description.trim() || null,
-      commands
-    });
+    if (!changeReason.trim()) {
+      onError?.('A reason for the change is required');
+      return;
+    }
+    await onCreate(
+      {
+        name: name.trim(),
+        description: description.trim() || null,
+        commands
+      },
+      changeReason.trim(),
+    );
   };
 
   return (
@@ -101,6 +114,19 @@ const CreateScheduleDialog: React.FC<CreateScheduleDialogProps> = ({
               onChange={e => setDescription(e.target.value)}
               multiline
               rows={2}
+              sx={{ mb: 2 }}
+            />
+            <TextField
+              fullWidth
+              required
+              label="Reason for change"
+              placeholder="e.g., new seasonal schedule, operator request, etc."
+              value={changeReason}
+              onChange={e => setChangeReason(e.target.value)}
+              multiline
+              rows={2}
+              error={!changeReason.trim()}
+              helperText="Required — appears in the schedule's change history."
               sx={{ mb: 3 }}
             />
 
@@ -127,7 +153,11 @@ const CreateScheduleDialog: React.FC<CreateScheduleDialogProps> = ({
         </DialogContent>
         <DialogActions>
           <Button onClick={onClose}>Cancel</Button>
-          <Button onClick={handleSubmit} variant="contained" disabled={!name.trim()}>
+          <Button
+            onClick={handleSubmit}
+            variant="contained"
+            disabled={!name.trim() || !changeReason.trim()}
+          >
             Create
           </Button>
         </DialogActions>

--- a/src/components/ScheduleLibrary/ScheduleLibrary.tsx
+++ b/src/components/ScheduleLibrary/ScheduleLibrary.tsx
@@ -106,15 +106,18 @@ const ScheduleLibrary: React.FC<ScheduleLibraryProps> = ({
     }
   };
 
-  const handleCreate = async (data: {
-    name: string;
-    description: string | null;
-    commands: ScheduleCommandDto[];
-  }) => {
+  const handleCreate = async (
+    data: {
+      name: string;
+      description: string | null;
+      commands: ScheduleCommandDto[];
+    },
+    changeReason: string,
+  ) => {
     setLoading(true);
     setError(null);
     try {
-      await createLibraryItem(siteId, data);
+      await createLibraryItem(siteId, { ...data, change_reason: changeReason });
       setCreateDialogOpen(false);
       await loadLibraryItems();
     } catch (err) {

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -8,7 +8,6 @@ import { CompanySelector } from '../CompanySelector/CompanySelector';
 import { useAuth } from '../../pages/LoginPage/useAuth';
 import { isAdmin } from '../../utils/auth';
 import { debugLog, errorLog } from '../../utils/debug';
-import { COMMAND_BAR_COLORS } from '../../utils/scheduleHelpers';
 
 interface SidebarProps {
   className?: string;
@@ -170,25 +169,6 @@ const Sidebar: React.FC<SidebarProps> = () => { // Removed unused className
         userRoles={userInfo?.roles || []}
         userCompanyName={userInfo?.company_name}
       />
-
-      <Divider />
-
-      <Box sx={{ px: collapsed ? 1 : 2, py: 1, display: 'flex', gap: collapsed ? 0.5 : 1.5, justifyContent: collapsed ? 'center' : 'flex-start', flexWrap: 'wrap' }}>
-        {([
-          { color: COMMAND_BAR_COLORS.charge, label: 'Charge' },
-          { color: COMMAND_BAR_COLORS.discharge, label: 'Discharge' },
-          { color: COMMAND_BAR_COLORS.trickle_charge, label: 'Trickle' },
-        ] as const).map(({ color, label }) => (
-          <Box key={label} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <Box sx={{ width: 10, height: 10, borderRadius: '50%', bgcolor: color, flexShrink: 0 }} />
-            {!collapsed && (
-              <Typography variant="caption" color="text.secondary" noWrap>
-                {label}
-              </Typography>
-            )}
-          </Box>
-        ))}
-      </Box>
 
       <Divider />
 

--- a/src/components/SiteDefaultsPanel/SiteDefaultsPanel.tsx
+++ b/src/components/SiteDefaultsPanel/SiteDefaultsPanel.tsx
@@ -153,20 +153,33 @@ const FIELD_HELP: Record<string, string> = {
     'Determines hardware constraints. "No grid charge" means inverters cannot charge from the grid.',
 };
 
-const FieldHelp: React.FC<{ field: string }> = ({ field }) => {
+// Target on-screen size of the help icon, in px.
+const FIELD_HELP_ICON_PX = 20;
+
+/**
+ * Inline "?" help icon + tooltip.
+ *
+ * `plain` distinguishes the two contexts this renders in so the icon ends up
+ * the same visual size in both. A populated MUI floating input label is
+ * transformed with `scale(0.75)`, which also shrinks an icon inside it; we
+ * counter that by sizing the icon up. Section headers and the switch label
+ * are un-scaled, so they use the target size directly (`plain`).
+ */
+const FieldHelp: React.FC<{ field: string; plain?: boolean }> = ({ field, plain }) => {
   const tip = FIELD_HELP[field];
   if (!tip) return null;
+  const fontSize = plain ? FIELD_HELP_ICON_PX : Math.round(FIELD_HELP_ICON_PX / 0.75);
   return (
     <Tooltip
       title={tip}
       arrow
       placement="top"
       slotProps={{
-        tooltip: { sx: { fontSize: '0.8rem', lineHeight: 1.5, maxWidth: 320, p: 1 } },
+        tooltip: { sx: { fontSize: '0.95rem', lineHeight: 1.5, maxWidth: 340, p: 1.25 } },
       }}
     >
       <HelpOutline
-        sx={{ fontSize: 20, ml: 0.5, verticalAlign: 'text-bottom', color: 'action.active', cursor: 'help' }}
+        sx={{ fontSize, ml: 0.5, verticalAlign: 'text-bottom', color: 'action.active', cursor: 'help' }}
       />
     </Tooltip>
   );
@@ -356,7 +369,7 @@ const SiteDefaultsPanel: React.FC<SiteDefaultsPanelProps> = ({ onSavingChange, r
                   onChange={e => setField('closed_loop_enabled', e.target.checked)}
                 />
               }
-              label={<>Closed-loop control enabled<FieldHelp field="closed_loop_enabled" /></>}
+              label={<>Closed-loop control enabled<FieldHelp field="closed_loop_enabled" plain /></>}
             />
             {!draft.closed_loop_enabled && (
               <Typography variant="caption" color="warning.main" display="block">
@@ -406,7 +419,7 @@ const SiteDefaultsPanel: React.FC<SiteDefaultsPanelProps> = ({ onSavingChange, r
 
         <Divider />
 
-        <Typography variant="subtitle1">Off-peak charging window<FieldHelp field="off_peak_window" /></Typography>
+        <Typography variant="subtitle1">Off-peak charging window<FieldHelp field="off_peak_window" plain /></Typography>
         <Grid container spacing={2}>
           <Grid size={{ xs: 6 }}>
             <TextField
@@ -430,7 +443,7 @@ const SiteDefaultsPanel: React.FC<SiteDefaultsPanelProps> = ({ onSavingChange, r
           </Grid>
         </Grid>
 
-        <Typography variant="subtitle1">Peak-revenue discharge window<FieldHelp field="peak_revenue_window" /></Typography>
+        <Typography variant="subtitle1">Peak-revenue discharge window<FieldHelp field="peak_revenue_window" plain /></Typography>
         <Grid container spacing={2}>
           <Grid size={{ xs: 6 }}>
             <TextField

--- a/src/components/SiteDefaultsPanel/SiteDefaultsPanel.tsx
+++ b/src/components/SiteDefaultsPanel/SiteDefaultsPanel.tsx
@@ -498,7 +498,10 @@ const SiteDefaultsPanel: React.FC<SiteDefaultsPanelProps> = ({ onSavingChange, r
               <Select
                 labelId="site-variant-label"
                 value={draft.site_variant}
-                label="Site variant"
+                // Match the InputLabel content (incl. the help icon) so the
+                // notched outline reserves width for the icon; a plain-string
+                // label here makes the border cut through the "?".
+                label={<>Site variant<FieldHelp field="site_variant" /></>}
                 onChange={e => setField('site_variant', e.target.value as SiteVariant)}
               >
                 <MenuItem value="standard">Standard interconnect</MenuItem>

--- a/src/components/SiteDefaultsPanel/SiteDefaultsPanel.tsx
+++ b/src/components/SiteDefaultsPanel/SiteDefaultsPanel.tsx
@@ -157,9 +157,16 @@ const FieldHelp: React.FC<{ field: string }> = ({ field }) => {
   const tip = FIELD_HELP[field];
   if (!tip) return null;
   return (
-    <Tooltip title={tip} arrow placement="top">
+    <Tooltip
+      title={tip}
+      arrow
+      placement="top"
+      slotProps={{
+        tooltip: { sx: { fontSize: '0.8rem', lineHeight: 1.5, maxWidth: 320, p: 1 } },
+      }}
+    >
       <HelpOutline
-        sx={{ fontSize: 16, ml: 0.5, verticalAlign: 'text-bottom', color: 'action.active', cursor: 'help' }}
+        sx={{ fontSize: 20, ml: 0.5, verticalAlign: 'text-bottom', color: 'action.active', cursor: 'help' }}
       />
     </Tooltip>
   );

--- a/src/pages/FDNYPage.tsx
+++ b/src/pages/FDNYPage.tsx
@@ -305,12 +305,13 @@ const FDNYPage: React.FC = () => {
                             />
                           </TableCell>
                           <TableCell>
-                            <Chip
-                              label={entry.active ? 'Activated' : 'Cleared'}
-                              color={entry.active ? 'error' : 'default'}
-                              variant={entry.active ? 'filled' : 'outlined'}
-                              size="small"
-                            />
+                            <Typography
+                              variant="body2"
+                              color={entry.active ? 'error.main' : 'text.secondary'}
+                              sx={{ fontWeight: entry.active ? 600 : 400 }}
+                            >
+                              {entry.active ? 'Activated' : 'Cleared'}
+                            </Typography>
                           </TableCell>
                           <TableCell>
                             {current && (

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -100,13 +100,28 @@ function formatMinutes(value: number): string {
   return m === 0 ? `${h}h` : `${h}h ${m}m`;
 }
 
+// Times on the SoC axis are shown in UTC (see the caption under the chart).
+// At a midnight boundary we signal the calendar date instead of "00:00" so a
+// 24h window that spans two days makes the day change obvious.
 function formatHourLabel(epochMs: number): string {
   const d = new Date(epochMs);
-  return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`;
+  if (d.getUTCHours() === 0) {
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', timeZone: 'UTC' });
+  }
+  return `${d.getUTCHours().toString().padStart(2, '0')}:00`;
 }
 
 function formatTooltipLabel(epochMs: number): string {
-  return new Date(epochMs).toLocaleString();
+  return (
+    new Date(epochMs).toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+      timeZone: 'UTC',
+    }) + ' UTC'
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -246,6 +261,17 @@ const ReportsPage: React.FC = () => {
     [nowMs],
   );
 
+  // Explicit ticks on every whole hour across the window, so the axis reads
+  // hourly regardless of where the sample points happen to fall.
+  const socHourTicks = useMemo(() => {
+    const [start, end] = socDomain;
+    const ticks: number[] = [];
+    for (let t = Math.ceil(start / 3600_000) * 3600_000; t <= end; t += 3600_000) {
+      ticks.push(t);
+    }
+    return ticks;
+  }, [socDomain]);
+
   const latestSoc = useMemo(() => {
     if (!socPoints || socPoints.length === 0) return null;
     return socPoints[socPoints.length - 1].soc;
@@ -348,9 +374,11 @@ const ReportsPage: React.FC = () => {
                         type="number"
                         domain={socDomain}
                         scale="time"
+                        ticks={socHourTicks}
                         tickFormatter={formatHourLabel}
                         stroke={theme.palette.text.secondary}
                         tick={{ fontSize: 12 }}
+                        minTickGap={16}
                       />
                       <YAxis
                         domain={[0, 100]}
@@ -377,6 +405,13 @@ const ReportsPage: React.FC = () => {
                       />
                     </BarChart>
                   </ResponsiveContainer>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ display: 'block', textAlign: 'right', mt: 0.5 }}
+                  >
+                    Times shown in UTC
+                  </Typography>
                 </Box>
               )}
             </CardContent>

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -268,6 +268,7 @@ const ChartExportButtons: React.FC<ChartExportProps> = ({
 // ---------------------------------------------------------------------------
 
 const SOC_WINDOW_HOURS = 24;
+const SOC_REFRESH_INTERVAL_MS = 60_000;
 
 const ReportsPage: React.FC = () => {
   const theme = useTheme();
@@ -279,6 +280,10 @@ const ReportsPage: React.FC = () => {
   const [nowMs, setNowMs] = useState(Date.now());
   const [socFrom, setSocFrom] = useState<Date>(() => new Date(Date.now() - SOC_WINDOW_HOURS * 3600_000));
   const [socTo, setSocTo] = useState<Date>(() => new Date());
+  // When live, the 24h window auto-advances to "now" every refresh tick.
+  // Editing From/To pins a custom range and turns this off; "Last 24h"
+  // turns it back on.
+  const [socLive, setSocLive] = useState(true);
   const socChartRef = useRef<HTMLDivElement | null>(null);
 
   // -- Charge/discharge chart state --
@@ -307,6 +312,18 @@ const ReportsPage: React.FC = () => {
   useEffect(() => {
     void loadSoc();
   }, [loadSoc]);
+
+  // While live, slide the 24h window to "now" every tick. Advancing the
+  // dates re-triggers loadSoc, so this also drives the periodic refresh.
+  useEffect(() => {
+    if (!socLive) return;
+    const id = setInterval(() => {
+      const now = new Date();
+      setSocTo(now);
+      setSocFrom(new Date(now.getTime() - SOC_WINDOW_HOURS * 3600_000));
+    }, SOC_REFRESH_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [socLive]);
 
   // -- Charge/discharge data loading --
   const loadCd = useCallback(async () => {
@@ -428,6 +445,7 @@ const ReportsPage: React.FC = () => {
                   <Typography variant="body2" color="text.secondary">
                     {latestSoc !== null && `Latest: ${latestSoc.toFixed(1)}% · `}
                     {bucketLabel(bucketMs / 60_000)} averages
+                    {socLive && ` · live, updates every ${SOC_REFRESH_INTERVAL_MS / 1000}s`}
                   </Typography>
                 </Box>
                 <TextField
@@ -437,7 +455,10 @@ const ReportsPage: React.FC = () => {
                   value={toDateTimeInput(socFrom)}
                   onChange={e => {
                     const d = fromDateTimeInput(e.target.value);
-                    if (d) setSocFrom(d);
+                    if (d) {
+                      setSocLive(false);
+                      setSocFrom(d);
+                    }
                   }}
                   slotProps={{ inputLabel: { shrink: true } }}
                 />
@@ -448,16 +469,21 @@ const ReportsPage: React.FC = () => {
                   value={toDateTimeInput(socTo)}
                   onChange={e => {
                     const d = fromDateTimeInput(e.target.value);
-                    if (d) setSocTo(d);
+                    if (d) {
+                      setSocLive(false);
+                      setSocTo(d);
+                    }
                   }}
                   slotProps={{ inputLabel: { shrink: true } }}
                 />
                 <Button
                   size="small"
+                  variant={socLive ? 'contained' : 'outlined'}
                   onClick={() => {
                     const now = new Date();
                     setSocTo(now);
                     setSocFrom(new Date(now.getTime() - SOC_WINDOW_HOURS * 3600_000));
+                    setSocLive(true);
                   }}
                 >
                   Last 24h

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -87,6 +87,86 @@ function fromDateInput(s: string): Date | null {
   return new Date(y, m - 1, d);
 }
 
+// datetime-local round-trip (local time) for the finer-grained SoC window.
+function toDateTimeInput(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function fromDateTimeInput(s: string): Date | null {
+  if (!s) return null;
+  const d = new Date(s);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+// ---------------------------------------------------------------------------
+// SoC histogram bucketing
+//
+// Over a wide range, plotting every 6-minute sample is unreadable and slow,
+// so we average samples into fixed-width buckets and draw one bar per bucket.
+// The bucket width grows with the span so the bar count stays bounded (a week
+// collapses to roughly hourly bars, a month to a few hours, etc.).
+// ---------------------------------------------------------------------------
+
+// Candidate bucket widths in minutes, smallest first. 6 min matches the
+// collector cadence (effectively "raw"); the rest are round wall-clock steps.
+const SOC_BUCKET_MINUTES = [6, 15, 30, 60, 180, 360, 720, 1440];
+const SOC_TARGET_BARS = 240;
+
+function pickBucketMinutes(spanMs: number): number {
+  const spanMin = spanMs / 60_000;
+  for (const m of SOC_BUCKET_MINUTES) {
+    if (spanMin / m <= SOC_TARGET_BARS) return m;
+  }
+  return SOC_BUCKET_MINUTES[SOC_BUCKET_MINUTES.length - 1];
+}
+
+function bucketLabel(minutes: number): string {
+  if (minutes < 60) return `${minutes}-minute`;
+  const hours = minutes / 60;
+  if (hours < 24) return hours === 1 ? 'hourly' : `${hours}-hour`;
+  const days = hours / 24;
+  return days === 1 ? 'daily' : `${days}-day`;
+}
+
+// Average SoC into epoch-aligned buckets (so hourly buckets land on the hour
+// in UTC, matching the axis). Each bucket is plotted at its start.
+function bucketSocPoints(points: SocChartPoint[], bucketMs: number): SocChartPoint[] {
+  if (bucketMs <= 0 || points.length === 0) return points;
+  const agg = new Map<number, { sum: number; count: number }>();
+  for (const p of points) {
+    const key = Math.floor(p.t / bucketMs) * bucketMs;
+    const cur = agg.get(key);
+    if (cur) {
+      cur.sum += p.soc;
+      cur.count += 1;
+    } else {
+      agg.set(key, { sum: p.soc, count: 1 });
+    }
+  }
+  return [...agg.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([t, { sum, count }]) => ({ t, soc: sum / count }));
+}
+
+// Axis ticks: a round wall-clock step chosen so there are ~10 labels.
+const SOC_TICK_MINUTES = [60, 120, 180, 360, 720, 1440, 2880, 10080];
+const SOC_TARGET_TICKS = 10;
+
+function pickTickMinutes(spanMs: number): number {
+  const spanMin = spanMs / 60_000;
+  for (const m of SOC_TICK_MINUTES) {
+    if (spanMin / m <= SOC_TARGET_TICKS) return m;
+  }
+  return SOC_TICK_MINUTES[SOC_TICK_MINUTES.length - 1];
+}
+
+function generateTicks(from: number, to: number, stepMs: number): number[] {
+  const ticks: number[] = [];
+  for (let t = Math.ceil(from / stepMs) * stepMs; t <= to; t += stepMs) ticks.push(t);
+  return ticks;
+}
+
 function formatDayLabel(day: string): string {
   const parts = day.split('-');
   if (parts.length !== 3) return day;
@@ -188,7 +268,6 @@ const ChartExportButtons: React.FC<ChartExportProps> = ({
 // ---------------------------------------------------------------------------
 
 const SOC_WINDOW_HOURS = 24;
-const SOC_REFRESH_INTERVAL_MS = 60_000;
 
 const ReportsPage: React.FC = () => {
   const theme = useTheme();
@@ -198,6 +277,8 @@ const ReportsPage: React.FC = () => {
   const [socPoints, setSocPoints] = useState<SocChartPoint[] | null>(null);
   const [socError, setSocError] = useState<string | null>(null);
   const [nowMs, setNowMs] = useState(Date.now());
+  const [socFrom, setSocFrom] = useState<Date>(() => new Date(Date.now() - SOC_WINDOW_HOURS * 3600_000));
+  const [socTo, setSocTo] = useState<Date>(() => new Date());
   const socChartRef = useRef<HTMLDivElement | null>(null);
 
   // -- Charge/discharge chart state --
@@ -209,26 +290,22 @@ const ReportsPage: React.FC = () => {
   const [cdLoading, setCdLoading] = useState(false);
   const cdChartRef = useRef<HTMLDivElement | null>(null);
 
-  // -- SoC data loading with auto-refresh --
+  // -- SoC data loading over the selected [socFrom, socTo] window --
   const loadSoc = useCallback(async () => {
     if (!selectedSite) return;
-    const now = new Date();
-    setNowMs(now.getTime());
-    const windowFrom = new Date(now.getTime() - SOC_WINDOW_HOURS * 3600_000);
+    setNowMs(Date.now());
     try {
-      const response = await fetchSocHistory(selectedSite.id, windowFrom, now);
+      const response = await fetchSocHistory(selectedSite.id, socFrom, socTo);
       setSocPoints(toSocChartPoints(response.points));
       setSocError(null);
     } catch (err) {
       errorLog('ReportsPage: SoC load failed', err);
       setSocError('Failed to load SoC history.');
     }
-  }, [selectedSite]);
+  }, [selectedSite, socFrom, socTo]);
 
   useEffect(() => {
     void loadSoc();
-    const interval = setInterval(() => { void loadSoc(); }, SOC_REFRESH_INTERVAL_MS);
-    return () => clearInterval(interval);
   }, [loadSoc]);
 
   // -- Charge/discharge data loading --
@@ -257,20 +334,27 @@ const ReportsPage: React.FC = () => {
 
   // -- Derived --
   const socDomain: [number, number] = useMemo(
-    () => [nowMs - SOC_WINDOW_HOURS * 3600_000, nowMs],
-    [nowMs],
+    () => [socFrom.getTime(), socTo.getTime()],
+    [socFrom, socTo],
+  );
+  const socSpanMs = socDomain[1] - socDomain[0];
+
+  // Bucket width grows with the span so a wide range averages into coarser
+  // bars (e.g. ~hourly over a week) instead of plotting every raw sample.
+  const bucketMs = useMemo(() => pickBucketMinutes(socSpanMs) * 60_000, [socSpanMs]);
+  const bucketedSocPoints = useMemo(
+    () => (socPoints ? bucketSocPoints(socPoints, bucketMs) : socPoints),
+    [socPoints, bucketMs],
   );
 
-  // Explicit ticks on every whole hour across the window, so the axis reads
-  // hourly regardless of where the sample points happen to fall.
-  const socHourTicks = useMemo(() => {
-    const [start, end] = socDomain;
-    const ticks: number[] = [];
-    for (let t = Math.ceil(start / 3600_000) * 3600_000; t <= end; t += 3600_000) {
-      ticks.push(t);
-    }
-    return ticks;
-  }, [socDomain]);
+  // Axis ticks on round wall-clock steps sized to the span (~10 labels).
+  const socTicks = useMemo(
+    () => generateTicks(socDomain[0], socDomain[1], pickTickMinutes(socSpanMs) * 60_000),
+    [socDomain, socSpanMs],
+  );
+
+  // Only draw the "Now" marker when the window actually includes now.
+  const showNow = nowMs >= socDomain[0] && nowMs <= socDomain[1];
 
   const latestSoc = useMemo(() => {
     if (!socPoints || socPoints.length === 0) return null;
@@ -333,17 +417,51 @@ const ReportsPage: React.FC = () => {
           {/* ---- SoC chart ---- */}
           <Card sx={{ mb: 3 }}>
             <CardContent>
-              <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1 }}>
-                <Box>
-                  <Typography variant="h6">
-                    Available state of charge — last {SOC_WINDOW_HOURS} hours
+              <Stack
+                direction={{ xs: 'column', md: 'row' }}
+                spacing={2}
+                alignItems={{ xs: 'stretch', md: 'center' }}
+                sx={{ mb: 1 }}
+              >
+                <Box sx={{ flex: 1 }}>
+                  <Typography variant="h6">Available state of charge</Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {latestSoc !== null && `Latest: ${latestSoc.toFixed(1)}% · `}
+                    {bucketLabel(bucketMs / 60_000)} averages
                   </Typography>
-                  {latestSoc !== null && (
-                    <Typography variant="body2" color="text.secondary">
-                      Latest: {latestSoc.toFixed(1)}% · updates every {SOC_REFRESH_INTERVAL_MS / 1000}s
-                    </Typography>
-                  )}
                 </Box>
+                <TextField
+                  type="datetime-local"
+                  label="From"
+                  size="small"
+                  value={toDateTimeInput(socFrom)}
+                  onChange={e => {
+                    const d = fromDateTimeInput(e.target.value);
+                    if (d) setSocFrom(d);
+                  }}
+                  slotProps={{ inputLabel: { shrink: true } }}
+                />
+                <TextField
+                  type="datetime-local"
+                  label="To"
+                  size="small"
+                  value={toDateTimeInput(socTo)}
+                  onChange={e => {
+                    const d = fromDateTimeInput(e.target.value);
+                    if (d) setSocTo(d);
+                  }}
+                  slotProps={{ inputLabel: { shrink: true } }}
+                />
+                <Button
+                  size="small"
+                  onClick={() => {
+                    const now = new Date();
+                    setSocTo(now);
+                    setSocFrom(new Date(now.getTime() - SOC_WINDOW_HOURS * 3600_000));
+                  }}
+                >
+                  Last 24h
+                </Button>
                 <ChartExportButtons
                   chartRef={socChartRef}
                   filePrefix={`soc-site-${selectedSite.id}`}
@@ -361,20 +479,21 @@ const ReportsPage: React.FC = () => {
                 </Box>
               ) : socPoints.length === 0 ? (
                 <Typography variant="body2" color="text.secondary">
-                  No SoC readings in the last {SOC_WINDOW_HOURS} hours. Seed history with{' '}
-                  <code>neems-data seed-soc-history --site-id {selectedSite.id}</code>.
+                  No SoC readings in this range. Seed history with{' '}
+                  <code>neems-data seed-soc-history --site-id {selectedSite.id}</code>{' '}
+                  or widen the window.
                 </Typography>
               ) : (
                 <Box ref={socChartRef}>
                   <ResponsiveContainer width="100%" height={280}>
-                    <BarChart data={socPoints} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                    <BarChart data={bucketedSocPoints ?? []} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
                       <CartesianGrid stroke={theme.palette.divider} strokeDasharray="3 3" />
                       <XAxis
                         dataKey="t"
                         type="number"
                         domain={socDomain}
                         scale="time"
-                        ticks={socHourTicks}
+                        ticks={socTicks}
                         tickFormatter={formatHourLabel}
                         stroke={theme.palette.text.secondary}
                         tick={{ fontSize: 12 }}
@@ -392,12 +511,14 @@ const ReportsPage: React.FC = () => {
                         formatter={(value) => [`${(value as number).toFixed(1)}%`, 'SoC']}
                         cursor={{ fill: theme.palette.action.hover }}
                       />
-                      <ReferenceLine
-                        x={nowMs}
-                        stroke={theme.palette.error.main}
-                        strokeDasharray="4 4"
-                        label={{ value: 'Now', position: 'top', fill: theme.palette.error.main, fontSize: 11 }}
-                      />
+                      {showNow && (
+                        <ReferenceLine
+                          x={nowMs}
+                          stroke={theme.palette.error.main}
+                          strokeDasharray="4 4"
+                          label={{ value: 'Now', position: 'top', fill: theme.palette.error.main, fontSize: 11 }}
+                        />
+                      )}
                       <Bar
                         dataKey="soc"
                         fill={theme.palette.primary.main}


### PR DESCRIPTION
A batch of demo/UX improvements to the Reports, Scheduler, and FDNY views.

**Scheduler calendar**
- Render the "now" indicator as a centered dark-gray dot instead of a full-height vertical line (it read like a charge/discharge signal).
- Move the charge/discharge/trickle color legend out of the sidebar to directly below the calendar grid (new reusable `ScheduleLegend`).

**Available State of Charge chart (Reports)**
- Hourly UTC axis ticks with date breaks at midnight; "Times shown in UTC" caption.
- From/To datetime range with adaptive averaging — samples bucket into coarser windows as the span widens (≈hourly over a week), targeting ~240 bars; axis ticks scale to ~10 labels.
- Live mode: default 24h window auto-advances every 60s; editing From/To pins a custom range; "Last 24h" returns to live.

**FDNY**
- Render the Activated/Cleared transition as plain text (error-color/semibold vs. muted) instead of a pill, for legibility.

**Schedule library**
- Require a "Reason for change" when creating a new schedule (parity with editing existing schedules); threaded through as `change_reason`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)