### PR TITLE
Closed-loop power-limit warning + tidy end-of-charge note

### DIFF
--- a/src/components/PeakSeasonWizard/PeakSeasonWizard.tsx
+++ b/src/components/PeakSeasonWizard/PeakSeasonWizard.tsx
@@ -347,7 +347,11 @@ const PeakSeasonWizard: React.FC<PeakSeasonWizardProps> = ({ open, onClose, onCo
               />
               {!draft.closed_loop_enabled && (
                 <Alert severity="warning">
-                  Schedules will be visualized but not enforced while closed-loop is off.
+                  {`Schedules will be visualized but not enforced while closed-loop is off. Without it, the site may import or export more power than the site power limit${
+                    draft.power_kw.trim() && !Number.isNaN(Number(draft.power_kw))
+                      ? ` (${Number(draft.power_kw).toLocaleString()} kW)`
+                      : ''
+                  }.`}
                 </Alert>
               )}
             </Stack>

--- a/src/components/PeakSeasonWizard/PeakSeasonWizard.tsx
+++ b/src/components/PeakSeasonWizard/PeakSeasonWizard.tsx
@@ -400,7 +400,6 @@ const PeakSeasonWizard: React.FC<PeakSeasonWizardProps> = ({ open, onClose, onCo
             <Stack spacing={2}>
               <Typography variant="body2" color="text.secondary">
                 Target State-of-Charge to hit by the end of the off-peak window.
-                The script's default is 100%.
               </Typography>
               <TextField
                 label="End-of-charge SoC"

--- a/src/components/PeakSeasonWizard/PeakSeasonWizard.tsx
+++ b/src/components/PeakSeasonWizard/PeakSeasonWizard.tsx
@@ -479,8 +479,7 @@ const PeakSeasonWizard: React.FC<PeakSeasonWizardProps> = ({ open, onClose, onCo
           {step === 6 && (
             <Stack spacing={2}>
               <Typography variant="body2" color="text.secondary">
-                Pick the season's start and end dates. Weekdays-only and the
-                federal-holiday skip are on by default to match the script.
+                Pick the season's start and end dates.
               </Typography>
               <TextField
                 label="Schedule name"

--- a/src/components/SiteDefaultsPanel/SiteDefaultsPanel.tsx
+++ b/src/components/SiteDefaultsPanel/SiteDefaultsPanel.tsx
@@ -373,7 +373,11 @@ const SiteDefaultsPanel: React.FC<SiteDefaultsPanelProps> = ({ onSavingChange, r
             />
             {!draft.closed_loop_enabled && (
               <Typography variant="caption" color="warning.main" display="block">
-                Schedules will be visualized but not enforced while closed-loop is off.
+                {`Schedules will be visualized but not enforced while closed-loop is off. Without it, the site may import or export more power than the site power limit${
+                  draft.power_kw.trim() && !Number.isNaN(Number(draft.power_kw))
+                    ? ` (${Number(draft.power_kw).toLocaleString()} kW)`
+                    : ''
+                }.`}
               </Typography>
             )}
           </Grid>


### PR DESCRIPTION
Follow-up copy tweaks to the site-power UX (after #81 merged).

- **Closed-loop warning** (Site defaults pane + peak-season wizard): when closed-loop control is off, the warning now also notes the site may import or export more power than the site power limit, filling in the live configured Site power value (e.g. "(5,000 kW)") when set.
- **End-of-charge note** (wizard): removed the stale "The script's default is 100%." sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)