### PR TITLE
Authenticate neems-react Docker build to GitHub Packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,14 @@ WORKDIR /app
 # Copy package files
 COPY package.json bun.lock ./
 
-# Install dependencies
-RUN bun install --frozen-lockfile
+# Install dependencies. @newtown-energy/types is published to GitHub Packages,
+# which requires auth even for public packages. The token is supplied as a
+# BuildKit secret (id=github_token) so it never lands in an image layer; we
+# write a throwaway .npmrc for the install only, then remove it.
+RUN --mount=type=secret,id=github_token \
+    printf '@newtown-energy:registry=https://npm.pkg.github.com\n//npm.pkg.github.com/:_authToken=%s\n' "$(cat /run/secrets/github_token)" > .npmrc \
+ && bun install --frozen-lockfile \
+ && rm -f .npmrc
 
 # Copy source code
 COPY . .

--- a/env.example
+++ b/env.example
@@ -14,7 +14,9 @@ NEEMS_CORE_SERVER=http://127.0.0.1:8000
 #NEEMS_TS_OUTPUT_DIR=
 
 # GitHub Packages auth token for installing @newtown-energy/types.
-# Only needed for local development outside Docker.
+# Needed for local development outside Docker, and also for building the
+# neems-react Docker image (passed to the build as a BuildKit secret via
+# docker-compose). Export it in the shell that runs `docker compose build`.
 # Easiest method using gh CLI:
 #   gh auth refresh -s read:packages  # One-time: add required scope
 #   export GITHUB_PACKAGES_TOKEN=$(gh auth token)


### PR DESCRIPTION
The image build ran `bun install --frozen-lockfile`, which fetches @newtown-energy/types from GitHub Packages. That registry requires auth even for public packages, so fresh builds failed with a 401.

Pass the token as a BuildKit secret (id=github_token), writing a throwaway .npmrc for the install step only so the token never lands in an image layer. Also correct the env.example comment, which wrongly claimed the token was only needed outside Docker.