### PR TITLE
Render alarms on the correct SLD element with their message

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "recharts": "^3.8.1",
       },
       "devDependencies": {
-        "@newtown-energy/types": "0.3.6",
+        "@newtown-energy/types": "0.3.7",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.0.10",
         "@types/react": "^19.1.8",
@@ -331,7 +331,7 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
-    "@newtown-energy/types": ["@newtown-energy/types@0.3.6", "https://npm.pkg.github.com/download/@newtown-energy/types/0.3.6/6f9663a5525fa48afecb7a256aaac91e3d278c52", {}, "sha512-70pALryT1EJNFDb4S7GtCyPCYmPxnFNeldWtAqUzwbnVbsJ4hMhnoxer58FX0fuaL8C/pe0P3SWrBSO+HuCdeA=="],
+    "@newtown-energy/types": ["@newtown-energy/types@0.3.7", "https://npm.pkg.github.com/download/@newtown-energy/types/0.3.7/5f15e2eaf8d8d4146287631b8de084cde3041bac", {}, "sha512-FzTG+d/iHaeSQO06WnLGJ2ExQ0AWuKT844BC6dWu6xV8stE2RsNcNmerbge48VuSenAWj+CEFK0CQp/bC/E/ww=="],
 
     "@parcel/watcher": ["@parcel/watcher@2.5.6", "", { "dependencies": { "detect-libc": "^2.0.3", "is-glob": "^4.0.3", "node-addon-api": "^7.0.0", "picomatch": "^4.0.3" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.6", "@parcel/watcher-darwin-arm64": "2.5.6", "@parcel/watcher-darwin-x64": "2.5.6", "@parcel/watcher-freebsd-x64": "2.5.6", "@parcel/watcher-linux-arm-glibc": "2.5.6", "@parcel/watcher-linux-arm-musl": "2.5.6", "@parcel/watcher-linux-arm64-glibc": "2.5.6", "@parcel/watcher-linux-arm64-musl": "2.5.6", "@parcel/watcher-linux-x64-glibc": "2.5.6", "@parcel/watcher-linux-x64-musl": "2.5.6", "@parcel/watcher-win32-arm64": "2.5.6", "@parcel/watcher-win32-ia32": "2.5.6", "@parcel/watcher-win32-x64": "2.5.6" } }, "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ=="],
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "npm run lint:eslint && npm run lint:tsc",
     "lint:eslint": "eslint ./src --max-warnings=0",
     "lint:tsc": "tsc --noEmit",
-    "test:unit": "bun test src/utils",
+    "test:unit": "bun test src",
     "preview": "vite preview",
     "generate-types": "dosh generate-types"
   },
@@ -27,7 +27,7 @@
     "recharts": "^3.8.1"
   },
   "devDependencies": {
-    "@newtown-energy/types": "0.3.6",
+    "@newtown-energy/types": "0.3.7",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.0.10",
     "@types/react": "^19.1.8",

--- a/src/components/SingleLineDiagram/SingleLineDiagram.tsx
+++ b/src/components/SingleLineDiagram/SingleLineDiagram.tsx
@@ -7,8 +7,10 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
+  useTheme,
 } from '@mui/material';
 import { visuallyHidden } from '@mui/utils';
+import { severityColor } from './elements/useStatusColors';
 import {
   ReactSVGPanZoom,
   TOOL_AUTO,
@@ -115,6 +117,7 @@ const SingleLineDiagram: React.FC<SingleLineDiagramProps> = ({
 }) => {
   const [state, dispatch] = useReducer(sldReducer, INITIAL_STATE);
   const [eStopDialogOpen, setEStopDialogOpen] = useState(false);
+  const theme = useTheme();
 
   // Pan/zoom viewer state. TOOL_AUTO gives click-through for buttons/switches
   // plus drag-to-pan and wheel/pinch zoom — the right default for a mixed
@@ -194,23 +197,23 @@ const SingleLineDiagram: React.FC<SingleLineDiagramProps> = ({
       }}
     >
       <CurtailmentBadge />
-      {/* Main-pane border overlay: blue = controls/electrical problem (site not
-          ready to operate), red = fire / life-safety emergency. Red is driven
-          by an Emergency in the fire alarm panel zone; blue by alarms targeting
-          the spreadsheet's 'Border' SLD object. The frame is decorative
-          (aria-hidden); the state is announced via the live region below. */}
+      {/* Main-pane border overlay: a flashing frame raised by site-level faults
+          (alarms targeting the spreadsheet's 'Border' SLD object, plus a fire
+          emergency in the FACP zone). Its color tracks the highest severity
+          among those alarms, matching the alarm-badge palette. The frame is
+          decorative (aria-hidden); the state is announced via the live region. */}
       {state.border && (
         <>
           <Box
             aria-hidden
-            data-testid={`sld-border-${state.border.kind}`}
+            data-testid={`sld-border-${state.border.severity}`}
             sx={{
               position: 'absolute',
               inset: 0,
               pointerEvents: 'none',
               zIndex: 5,
               border: '4px solid',
-              borderColor: state.border.kind === 'fire' ? 'error.main' : 'info.main',
+              borderColor: severityColor(state.border.severity, theme),
               borderRadius: 1,
               animation: 'sldBorderFlash 1.2s steps(1, end) infinite',
               '@keyframes sldBorderFlash': {
@@ -220,9 +223,7 @@ const SingleLineDiagram: React.FC<SingleLineDiagramProps> = ({
             }}
           />
           <Box role="status" aria-live="assertive" sx={visuallyHidden}>
-            {state.border.kind === 'fire'
-              ? 'Site emergency: fire or life-safety alarm active'
-              : 'Site not ready to operate: controls alarm active'}
+            {`Site-level ${state.border.severity.toLowerCase()} alarm active`}
           </Box>
         </>
       )}

--- a/src/components/SingleLineDiagram/SingleLineDiagram.tsx
+++ b/src/components/SingleLineDiagram/SingleLineDiagram.tsx
@@ -8,6 +8,7 @@ import {
   DialogContentText,
   DialogTitle,
 } from '@mui/material';
+import { visuallyHidden } from '@mui/utils';
 import {
   ReactSVGPanZoom,
   TOOL_AUTO,
@@ -32,26 +33,30 @@ const DIAGRAM_HEIGHT = 800;
 
 // --- Initial component definitions for Newtown site ---
 
+// The 4th argument is the set of "Related SLD Object" tokens (from the alarm
+// spreadsheet) a component represents, so alarms route to the precise element
+// rather than every component sharing a zone. Tokens with no element yet
+// (`Net`, `M1`/`M2`, `SST-UPS`, `CE_SCADA`, `Estop`) fall back to zone matching.
 const INITIAL_COMPONENTS = [
   defComponent('site', 'Site'),
-  defComponent('meter-main', 'Meter'),
+  defComponent('meter-main', 'Meter', undefined, ['Meter']),
   // SEL-451 protective relay. Kept under the BreakerRelay zone (it's the
   // relay that alarms publish against), but rendered as an off-line control
   // box with dashed supervision lines to the two 89L switches.
-  defComponent('breaker-main', 'BreakerRelay'),
-  defComponent('switch-89l-1', 'BreakerRelay', 'closed'),
-  defComponent('switch-89l-2', 'BreakerRelay', 'closed'),
-  defComponent('transformer-1', 'Transformer1'),
-  defComponent('transformer-2', 'Transformer2'),
+  defComponent('breaker-main', 'BreakerRelay', undefined, ['Relay']),
+  defComponent('switch-89l-1', 'BreakerRelay', 'closed', ['52-MAIN-1']),
+  defComponent('switch-89l-2', 'BreakerRelay', 'closed', ['52-MAIN-2']),
+  defComponent('transformer-1', 'Transformer1', undefined, ['T1']),
+  defComponent('transformer-2', 'Transformer2', undefined, ['T2']),
   defComponent('rtac', 'Rtac'),
-  defComponent('fire-alarm-panel', 'Facp'),
+  defComponent('fire-alarm-panel', 'Facp', undefined, ['FACP']),
   defComponent('tesla-site-controller', 'TeslaSiteController'),
-  defComponent('megapack-1a', 'Mp1a'),
-  defComponent('megapack-1b', 'Mp1b'),
-  defComponent('megapack-1c', 'Mp1c'),
-  defComponent('megapack-2a', 'Mp2a'),
-  defComponent('megapack-2b', 'Mp2b'),
-  defComponent('megapack-2c', 'Mp2c'),
+  defComponent('megapack-1a', 'Mp1a', undefined, ['MP-1A']),
+  defComponent('megapack-1b', 'Mp1b', undefined, ['MP-1B']),
+  defComponent('megapack-1c', 'Mp1c', undefined, ['MP-1C']),
+  defComponent('megapack-2a', 'Mp2a', undefined, ['MP-2A']),
+  defComponent('megapack-2b', 'Mp2b', undefined, ['MP-2B']),
+  defComponent('megapack-2c', 'Mp2c', undefined, ['MP-2C']),
   defComponent('feeder-1a', 'TeslaSiteController', 'closed'),
   defComponent('feeder-1b', 'TeslaSiteController', 'closed'),
   defComponent('feeder-1c', 'TeslaSiteController', 'closed'),
@@ -61,7 +66,7 @@ const INITIAL_COMPONENTS = [
   // Lockout relay — physical breaker-control handle driven by the SEL-451.
   // Shares the BreakerRelay zone for alarm mapping. 'closed' = CLOSE (normal),
   // 'open' = TRIP (breaker tripped / locked out).
-  defComponent('lockout-relay', 'BreakerRelay', 'closed'),
+  defComponent('lockout-relay', 'BreakerRelay', 'closed', ['LOR']),
 ];
 
 const INITIAL_WIRES = [
@@ -189,6 +194,38 @@ const SingleLineDiagram: React.FC<SingleLineDiagramProps> = ({
       }}
     >
       <CurtailmentBadge />
+      {/* Main-pane border overlay: blue = controls/electrical problem (site not
+          ready to operate), red = fire / life-safety emergency. Red is driven
+          by an Emergency in the fire alarm panel zone; blue by alarms targeting
+          the spreadsheet's 'Border' SLD object. The frame is decorative
+          (aria-hidden); the state is announced via the live region below. */}
+      {state.border && (
+        <>
+          <Box
+            aria-hidden
+            data-testid={`sld-border-${state.border.kind}`}
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              pointerEvents: 'none',
+              zIndex: 5,
+              border: '4px solid',
+              borderColor: state.border.kind === 'fire' ? 'error.main' : 'info.main',
+              borderRadius: 1,
+              animation: 'sldBorderFlash 1.2s steps(1, end) infinite',
+              '@keyframes sldBorderFlash': {
+                '0%, 50%': { opacity: 1 },
+                '50.01%, 100%': { opacity: 0.25 },
+              },
+            }}
+          />
+          <Box role="status" aria-live="assertive" sx={visuallyHidden}>
+            {state.border.kind === 'fire'
+              ? 'Site emergency: fire or life-safety alarm active'
+              : 'Site not ready to operate: controls alarm active'}
+          </Box>
+        </>
+      )}
       {viewerSize && (
         <ReactSVGPanZoom
           ref={viewerRef}

--- a/src/components/SingleLineDiagram/elements/AlarmIndicator.tsx
+++ b/src/components/SingleLineDiagram/elements/AlarmIndicator.tsx
@@ -179,24 +179,33 @@ const AlarmIndicator: React.FC<AlarmIndicatorProps> = ({ state, offsetX, offsetY
                 void ackTick;
                 const acked = isAlarmAcknowledged(alarm.alarm_num);
                 return (
-                  <Box
-                    key={alarm.alarm_num}
-                    sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
-                  >
-                    <Chip
-                      label={formatAlarmName(alarm.name)}
-                      color={getSeverityColor(alarm.severity)}
-                      size="small"
-                      variant={acked ? 'filled' : 'outlined'}
-                      sx={{ flex: 1, opacity: acked ? 0.7 : 1 }}
-                    />
-                    <Button
-                      size="small"
-                      variant={acked ? 'outlined' : 'text'}
-                      onClick={() => handleAcknowledgeOne(alarm)}
-                    >
-                      {acked ? 'Unack' : 'Ack'}
-                    </Button>
+                  <Box key={alarm.alarm_num}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <Chip
+                        label={formatAlarmName(alarm.name)}
+                        color={getSeverityColor(alarm.severity)}
+                        size="small"
+                        variant={acked ? 'filled' : 'outlined'}
+                        sx={{ flex: 1, opacity: acked ? 0.7 : 1 }}
+                      />
+                      <Button
+                        size="small"
+                        variant={acked ? 'outlined' : 'text'}
+                        onClick={() => handleAcknowledgeOne(alarm)}
+                      >
+                        {acked ? 'Unack' : 'Ack'}
+                      </Button>
+                    </Box>
+                    {alarm.message && (
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        component="div"
+                        sx={{ pl: 0.5, mt: 0.25, opacity: acked ? 0.7 : 1 }}
+                      >
+                        {alarm.message}
+                      </Typography>
+                    )}
                   </Box>
                 );
               })}

--- a/src/components/SingleLineDiagram/elements/UtilityConnection.tsx
+++ b/src/components/SingleLineDiagram/elements/UtilityConnection.tsx
@@ -6,8 +6,7 @@ import AlarmIndicator from './AlarmIndicator';
 
 /**
  * Utility line-in connection: a downward-pointing triangle meeting the power
- * line, with a labeled box (the line/circuit number, e.g. "ConEd 6Q81") to
- * the right.
+ * line, with a labeled box (the utility line/circuit number) to the right.
  */
 const UtilityConnection: React.FC<SldElementProps> = ({
   x,

--- a/src/components/SingleLineDiagram/sldState.test.ts
+++ b/src/components/SingleLineDiagram/sldState.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for the SLD reducer's alarm routing: token-based targeting,
+ * message plumbing, zone fallback, and the main-pane border state.
+ *
+ * Run with `bun test src/components/SingleLineDiagram/sldState.test.ts`.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { ActiveAlarmDto, ActiveAlarmsResponse } from '@newtown-energy/types';
+import { sldReducer, createInitialState, defComponent } from './sldState';
+
+function makeState() {
+  return createInitialState(
+    [
+      defComponent('site', 'Site'),
+      defComponent('meter-main', 'Meter', undefined, ['Meter']),
+      defComponent('breaker-main', 'BreakerRelay', undefined, ['Relay']),
+      defComponent('switch-89l-1', 'BreakerRelay', 'closed', ['52-MAIN-1']),
+      defComponent('switch-89l-2', 'BreakerRelay', 'closed', ['52-MAIN-2']),
+      defComponent('lockout-relay', 'BreakerRelay', 'closed', ['LOR']),
+      defComponent('fire-alarm-panel', 'Facp', undefined, ['FACP']),
+      defComponent('megapack-1a', 'Mp1a', undefined, ['MP-1A']),
+      defComponent('tesla-site-controller', 'TeslaSiteController'),
+      defComponent('feeder-1a', 'TeslaSiteController', 'closed'),
+    ],
+    [],
+  );
+}
+
+function alarm(partial: Partial<ActiveAlarmDto> & Pick<ActiveAlarmDto, 'alarm_num' | 'zone'>): ActiveAlarmDto {
+  return {
+    name: 'test_alarm',
+    severity: 'Warning',
+    message: null,
+    sld_targets: [],
+    ...partial,
+  };
+}
+
+function response(alarms: ActiveAlarmDto[]): ActiveAlarmsResponse {
+  return {
+    alarms,
+    has_critical: false,
+    has_emergency: false,
+    timestamp: '2026-06-19T00:00:00Z',
+    data_age_seconds: 0,
+  };
+}
+
+function apply(alarms: ActiveAlarmDto[]) {
+  return sldReducer(makeState(), { type: 'UPDATE_ALARMS', alarms: response(alarms) });
+}
+
+describe('sldReducer alarm routing', () => {
+  test('routes by SLD-object token, not just zone', () => {
+    // A BreakerRelay-zone alarm targeting 52-MAIN-1 must land on the switch
+    // only — NOT on every BreakerRelay component (breaker-main, lockout, etc.).
+    const state = apply([
+      alarm({ alarm_num: 101, zone: 'BreakerRelay', sld_targets: ['52-MAIN-1'] }),
+    ]);
+    expect(state.components['switch-89l-1'].activeAlarmCount).toBe(1);
+    expect(state.components['breaker-main'].activeAlarmCount).toBe(0);
+    expect(state.components['switch-89l-2'].activeAlarmCount).toBe(0);
+    expect(state.components['lockout-relay'].activeAlarmCount).toBe(0);
+  });
+
+  test('relay alarms hit only the relay element', () => {
+    const state = apply([
+      alarm({ alarm_num: 107, zone: 'BreakerRelay', sld_targets: ['Relay'] }),
+    ]);
+    expect(state.components['breaker-main'].activeAlarmCount).toBe(1);
+    expect(state.components['switch-89l-1'].activeAlarmCount).toBe(0);
+  });
+
+  test('carries the operator message onto the active alarm', () => {
+    const state = apply([
+      alarm({ alarm_num: 101, zone: 'BreakerRelay', sld_targets: ['52-MAIN-1'], message: '89L1 Open' }),
+    ]);
+    expect(state.components['switch-89l-1'].activeAlarms[0].message).toBe('89L1 Open');
+  });
+
+  test('falls back to zone matching when no token maps to a component', () => {
+    // M1/M2 have no element yet — a Tesla alarm targeting M1 should still light
+    // up the TeslaSiteController-zone components.
+    const state = apply([
+      alarm({ alarm_num: 501, zone: 'TeslaSiteController', sld_targets: ['M1'] }),
+    ]);
+    expect(state.components['tesla-site-controller'].activeAlarmCount).toBe(1);
+    expect(state.components['feeder-1a'].activeAlarmCount).toBe(1);
+  });
+
+  test('Border-targeted controls alarm sets a blue (controls) border', () => {
+    const state = apply([
+      alarm({ alarm_num: 103, zone: 'BreakerRelay', severity: 'Critical', sld_targets: ['LOR', 'Border'] }),
+    ]);
+    expect(state.border).toEqual({ kind: 'controls' });
+    // The non-Border token still routes to the lockout relay.
+    expect(state.components['lockout-relay'].activeAlarmCount).toBe(1);
+  });
+
+  test('a non-fire emergency does not set a fire border', () => {
+    // An Emergency outside the fire alarm panel zone must NOT paint the red
+    // life-safety frame — it still lights its own element, but no border.
+    const state = apply([
+      alarm({ alarm_num: 601, zone: 'Mp1a', severity: 'Emergency', sld_targets: ['MP-1A'] }),
+    ]);
+    expect(state.border).toBeNull();
+    expect(state.components['megapack-1a'].activeAlarmCount).toBe(1);
+  });
+
+  test('a Border-only alarm sets the frame without lighting components', () => {
+    // Targeting only 'Border' is a site-level frame signal; it must not spill
+    // onto every component sharing the alarm's zone.
+    const state = apply([
+      alarm({ alarm_num: 103, zone: 'BreakerRelay', severity: 'Critical', sld_targets: ['Border'] }),
+    ]);
+    expect(state.border).toEqual({ kind: 'controls' });
+    expect(state.components['breaker-main'].activeAlarmCount).toBe(0);
+    expect(state.components['switch-89l-1'].activeAlarmCount).toBe(0);
+    expect(state.components['lockout-relay'].activeAlarmCount).toBe(0);
+  });
+
+  test('an emergency sets a red (fire) border, outranking controls', () => {
+    const state = apply([
+      alarm({ alarm_num: 401, zone: 'Facp', severity: 'Emergency', sld_targets: ['FACP'], message: 'FIRE!!' }),
+      alarm({ alarm_num: 103, zone: 'BreakerRelay', severity: 'Critical', sld_targets: ['Border'] }),
+    ]);
+    expect(state.border).toEqual({ kind: 'fire' });
+    expect(state.components['fire-alarm-panel'].activeAlarms[0].message).toBe('FIRE!!');
+  });
+
+  test('no border when nothing targets it and there is no emergency', () => {
+    const state = apply([
+      alarm({ alarm_num: 107, zone: 'BreakerRelay', sld_targets: ['Relay'] }),
+    ]);
+    expect(state.border).toBeNull();
+  });
+});

--- a/src/components/SingleLineDiagram/sldState.test.ts
+++ b/src/components/SingleLineDiagram/sldState.test.ts
@@ -89,18 +89,20 @@ describe('sldReducer alarm routing', () => {
     expect(state.components['feeder-1a'].activeAlarmCount).toBe(1);
   });
 
-  test('Border-targeted controls alarm sets a blue (controls) border', () => {
+  test('a Border-targeted alarm colors the frame by its severity', () => {
+    // A critical controls fault paints the frame in its own severity color
+    // (critical), not an unintuitive fixed blue.
     const state = apply([
       alarm({ alarm_num: 103, zone: 'BreakerRelay', severity: 'Critical', sld_targets: ['LOR', 'Border'] }),
     ]);
-    expect(state.border).toEqual({ kind: 'controls' });
+    expect(state.border).toEqual({ severity: 'Critical' });
     // The non-Border token still routes to the lockout relay.
     expect(state.components['lockout-relay'].activeAlarmCount).toBe(1);
   });
 
-  test('a non-fire emergency does not set a fire border', () => {
-    // An Emergency outside the fire alarm panel zone must NOT paint the red
-    // life-safety frame — it still lights its own element, but no border.
+  test('a non-fire emergency does not raise the frame', () => {
+    // An Emergency outside the fire alarm panel zone with no Border target must
+    // NOT paint the frame — it still lights its own element, but no border.
     const state = apply([
       alarm({ alarm_num: 601, zone: 'Mp1a', severity: 'Emergency', sld_targets: ['MP-1A'] }),
     ]);
@@ -114,22 +116,24 @@ describe('sldReducer alarm routing', () => {
     const state = apply([
       alarm({ alarm_num: 103, zone: 'BreakerRelay', severity: 'Critical', sld_targets: ['Border'] }),
     ]);
-    expect(state.border).toEqual({ kind: 'controls' });
+    expect(state.border).toEqual({ severity: 'Critical' });
     expect(state.components['breaker-main'].activeAlarmCount).toBe(0);
     expect(state.components['switch-89l-1'].activeAlarmCount).toBe(0);
     expect(state.components['lockout-relay'].activeAlarmCount).toBe(0);
   });
 
-  test('an emergency sets a red (fire) border, outranking controls', () => {
+  test('the frame takes the highest severity among triggering alarms', () => {
+    // A fire emergency (FACP zone) plus a critical controls fault → the frame
+    // shows the most severe (emergency) color.
     const state = apply([
       alarm({ alarm_num: 401, zone: 'Facp', severity: 'Emergency', sld_targets: ['FACP'], message: 'FIRE!!' }),
       alarm({ alarm_num: 103, zone: 'BreakerRelay', severity: 'Critical', sld_targets: ['Border'] }),
     ]);
-    expect(state.border).toEqual({ kind: 'fire' });
+    expect(state.border).toEqual({ severity: 'Emergency' });
     expect(state.components['fire-alarm-panel'].activeAlarms[0].message).toBe('FIRE!!');
   });
 
-  test('no border when nothing targets it and there is no emergency', () => {
+  test('no border when nothing targets it and there is no fire emergency', () => {
     const state = apply([
       alarm({ alarm_num: 107, zone: 'BreakerRelay', sld_targets: ['Relay'] }),
     ]);

--- a/src/components/SingleLineDiagram/sldState.ts
+++ b/src/components/SingleLineDiagram/sldState.ts
@@ -3,11 +3,55 @@ import { getSeverityOrder } from '../../utils/alarmHelpers';
 import { resolveAlarmSeverity } from '../../config/siteConfig';
 import type {
   ActiveAlarmSummary,
+  SldBorderState,
   SldComponentState,
   SldDiagramState,
   SldWireState,
   PowerFlowDirection,
 } from './types';
+
+/** Spreadsheet token for the main-pane border/frame (not a diagram component). */
+const BORDER_TOKEN = 'Border';
+
+/** Alarm zone of the fire alarm panel — drives the red life-safety frame. */
+const FIRE_ZONE: AlarmZoneDto = 'Facp';
+
+function zoneIds(
+  components: Record<string, SldComponentState>,
+  zone: SldComponentState['zone'],
+): string[] {
+  return Object.values(components)
+    .filter((c) => c.zone === zone)
+    .map((c) => c.id);
+}
+
+/**
+ * Resolve which component ids an active alarm should light up. Prefers explicit
+ * "Related SLD Object" token targeting (matching `alarm.sld_targets` against
+ * each component's `sldTokens`); falls back to zone matching when the alarm's
+ * tokens correspond to no component yet (e.g. `Net`, `M1`/`M2`, `SST-UPS`).
+ */
+function resolveAlarmTargets(
+  components: Record<string, SldComponentState>,
+  zone: SldComponentState['zone'],
+  sldTargets: string[],
+): string[] {
+  const tokens = sldTargets.filter((t) => t !== BORDER_TOKEN);
+  if (tokens.length > 0) {
+    const matched = Object.values(components)
+      .filter((c) => c.sldTokens?.some((t) => tokens.includes(t)))
+      .map((c) => c.id);
+    if (matched.length > 0) return matched;
+    // Tokens present but mapping to no element yet (e.g. `Net`, `M1`/`M2`,
+    // `SST-UPS`) — fall back to lighting the whole zone.
+    return zoneIds(components, zone);
+  }
+  // The only target was the pane border: a frame-only/site-level alarm. Don't
+  // spill it onto every component in the zone.
+  if (sldTargets.includes(BORDER_TOKEN)) return [];
+  // Truly untargeted alarm — fall back to zone matching.
+  return zoneIds(components, zone);
+}
 
 // --- Actions ---
 
@@ -37,47 +81,66 @@ function applyAlarms(
     };
   }
 
-  // Map alarms to components by zone
+  // Route each alarm to its target component(s) and fold in the main-pane
+  // border state. Per the spreadsheet's guidance, the pane border is red for a
+  // fire / life-safety emergency (an Emergency in the fire alarm panel zone)
+  // and blue for a controls/electrical problem that leaves the site not ready
+  // to operate (the `Border`-targeted alarms, the "site offline" controls
+  // faults). A non-fire Emergency elsewhere does not paint the red frame.
+  let borderFire = false;
+  let borderControls = false;
+
   for (const alarm of alarms.alarms) {
     // Apply any per-site alarm-level override before computing severity-driven state.
     const severity = resolveAlarmSeverity(alarm.alarm_num, alarm.severity);
+    const sldTargets = alarm.sld_targets ?? [];
 
-    // Find component(s) matching this alarm's zone
-    for (const [id, comp] of Object.entries(updatedComponents)) {
-      if (comp.zone === alarm.zone) {
-        const currentOrder = comp.highestSeverity
-          ? getSeverityOrder(comp.highestSeverity)
-          : Infinity;
-        const newOrder = getSeverityOrder(severity);
+    const alarmSummary: ActiveAlarmSummary = {
+      alarm_num: alarm.alarm_num,
+      name: alarm.name,
+      severity,
+      message: alarm.message ?? null,
+    };
 
-        const alarmSummary: ActiveAlarmSummary = {
-          alarm_num: alarm.alarm_num,
-          name: alarm.name,
-          severity,
-        };
+    if (severity === 'Emergency' && alarm.zone === FIRE_ZONE) borderFire = true;
+    if (sldTargets.includes(BORDER_TOKEN)) borderControls = true;
 
-        updatedComponents[id] = {
-          ...comp,
-          activeAlarmCount: comp.activeAlarmCount + 1,
-          activeAlarms: [...comp.activeAlarms, alarmSummary],
-          highestSeverity:
-            newOrder < currentOrder ? severity : comp.highestSeverity,
-          status:
-            severity === 'Emergency' || severity === 'Critical'
-              ? 'alarm'
-              : severity === 'Warning'
-                ? comp.status === 'alarm'
-                  ? 'alarm'
-                  : 'warning'
-                : comp.status,
-        };
-      }
+    const targetIds = resolveAlarmTargets(updatedComponents, alarm.zone, sldTargets);
+    for (const id of targetIds) {
+      const comp = updatedComponents[id];
+      const currentOrder = comp.highestSeverity
+        ? getSeverityOrder(comp.highestSeverity)
+        : Infinity;
+      const newOrder = getSeverityOrder(severity);
+
+      updatedComponents[id] = {
+        ...comp,
+        activeAlarmCount: comp.activeAlarmCount + 1,
+        activeAlarms: [...comp.activeAlarms, alarmSummary],
+        highestSeverity:
+          newOrder < currentOrder ? severity : comp.highestSeverity,
+        status:
+          severity === 'Emergency' || severity === 'Critical'
+            ? 'alarm'
+            : severity === 'Warning'
+              ? comp.status === 'alarm'
+                ? 'alarm'
+                : 'warning'
+              : comp.status,
+      };
     }
   }
+
+  const border: SldBorderState = borderFire
+    ? { kind: 'fire' }
+    : borderControls
+      ? { kind: 'controls' }
+      : null;
 
   return {
     ...state,
     components: updatedComponents,
+    border,
     lastAlarmUpdate: alarms.timestamp,
     dataAgeSeconds:
       alarms.data_age_seconds != null ? Number(alarms.data_age_seconds) : null,
@@ -169,6 +232,7 @@ export function createInitialState(
   return {
     components: componentMap,
     wires: wireMap,
+    border: null,
     lastAlarmUpdate: null,
     dataAgeSeconds: null,
     dataStale: false,
@@ -181,10 +245,12 @@ export function defComponent(
   id: string,
   zone: AlarmZoneDto,
   switchPosition?: 'open' | 'closed',
+  sldTokens?: string[],
 ): SldComponentState {
   return {
     id,
     zone,
+    sldTokens,
     status: 'normal',
     highestSeverity: null,
     activeAlarmCount: 0,

--- a/src/components/SingleLineDiagram/sldState.ts
+++ b/src/components/SingleLineDiagram/sldState.ts
@@ -1,4 +1,4 @@
-import type { ActiveAlarmsResponse, AlarmZoneDto } from '@newtown-energy/types';
+import type { ActiveAlarmsResponse, AlarmSeverityDto, AlarmZoneDto } from '@newtown-energy/types';
 import { getSeverityOrder } from '../../utils/alarmHelpers';
 import { resolveAlarmSeverity } from '../../config/siteConfig';
 import type {
@@ -82,13 +82,12 @@ function applyAlarms(
   }
 
   // Route each alarm to its target component(s) and fold in the main-pane
-  // border state. Per the spreadsheet's guidance, the pane border is red for a
-  // fire / life-safety emergency (an Emergency in the fire alarm panel zone)
-  // and blue for a controls/electrical problem that leaves the site not ready
-  // to operate (the `Border`-targeted alarms, the "site offline" controls
-  // faults). A non-fire Emergency elsewhere does not paint the red frame.
-  let borderFire = false;
-  let borderControls = false;
+  // border state. The frame is raised by alarms that target the `Border` SLD
+  // object (the spreadsheet's "site not ready to operate" controls faults) and
+  // by a fire / life-safety emergency in the FACP zone. Its color tracks the
+  // highest severity among those triggering alarms — matching the alarm-badge
+  // palette — so a critical fault reads red/orange, not an unintuitive blue.
+  let borderSeverity: AlarmSeverityDto | null = null;
 
   for (const alarm of alarms.alarms) {
     // Apply any per-site alarm-level override before computing severity-driven state.
@@ -102,8 +101,16 @@ function applyAlarms(
       message: alarm.message ?? null,
     };
 
-    if (severity === 'Emergency' && alarm.zone === FIRE_ZONE) borderFire = true;
-    if (sldTargets.includes(BORDER_TOKEN)) borderControls = true;
+    const raisesBorder =
+      sldTargets.includes(BORDER_TOKEN) ||
+      (severity === 'Emergency' && alarm.zone === FIRE_ZONE);
+    if (
+      raisesBorder &&
+      (borderSeverity === null ||
+        getSeverityOrder(severity) < getSeverityOrder(borderSeverity))
+    ) {
+      borderSeverity = severity;
+    }
 
     const targetIds = resolveAlarmTargets(updatedComponents, alarm.zone, sldTargets);
     for (const id of targetIds) {
@@ -131,11 +138,7 @@ function applyAlarms(
     }
   }
 
-  const border: SldBorderState = borderFire
-    ? { kind: 'fire' }
-    : borderControls
-      ? { kind: 'controls' }
-      : null;
+  const border: SldBorderState = borderSeverity ? { severity: borderSeverity } : null;
 
   return {
     ...state,

--- a/src/components/SingleLineDiagram/types.ts
+++ b/src/components/SingleLineDiagram/types.ts
@@ -65,11 +65,14 @@ export interface SldWireState {
 }
 
 /**
- * Main-pane border state, driven by alarms targeting the `'Border'` SLD object.
- * Per the spreadsheet: blue border = controls/electrical problem (site not ready
- * to operate), red border = fire / life-safety emergency. `null` = no frame.
+ * Main-pane border state. Driven by alarms that target the `'Border'` SLD object
+ * (the spreadsheet's "site not ready to operate" controls faults) plus a fire /
+ * life-safety emergency in the FACP zone. The frame is colored by the highest
+ * severity among those triggering alarms, matching the alarm-badge palette, so a
+ * critical fault reads red/orange rather than an unintuitive blue. `null` = no
+ * frame.
  */
-export type SldBorderState = { kind: 'fire' | 'controls' } | null;
+export type SldBorderState = { severity: AlarmSeverityDto } | null;
 
 /** Top-level diagram state */
 export interface SldDiagramState {

--- a/src/components/SingleLineDiagram/types.ts
+++ b/src/components/SingleLineDiagram/types.ts
@@ -7,6 +7,9 @@ export interface ActiveAlarmSummary {
   alarm_num: number;
   name: string;
   severity: AlarmSeverityDto;
+  /** Operator-facing message from the alarm spreadsheet ("Mouseover").
+   *  `null` when the spreadsheet had none — callers fall back to the name. */
+  message: string | null;
 }
 
 /** The visual state of a single SLD component */
@@ -32,6 +35,13 @@ export type PowerFlowDirection = 'forward' | 'reverse' | 'none';
 export interface SldComponentState {
   id: string;
   zone: AlarmZoneDto;
+  /**
+   * "Related SLD Object" tokens this component represents (e.g. `'52-MAIN-1'`,
+   * `'LOR'`, `'Relay'`). An alarm whose `sld_targets` intersect these tokens is
+   * routed to this component — finer than zone matching. Omitted = match by
+   * zone only.
+   */
+  sldTokens?: string[];
   status: ComponentStatus;
   highestSeverity: AlarmSeverityDto | null;
   activeAlarmCount: number;
@@ -54,10 +64,19 @@ export interface SldWireState {
   powerFlow: PowerFlowDirection;
 }
 
+/**
+ * Main-pane border state, driven by alarms targeting the `'Border'` SLD object.
+ * Per the spreadsheet: blue border = controls/electrical problem (site not ready
+ * to operate), red border = fire / life-safety emergency. `null` = no frame.
+ */
+export type SldBorderState = { kind: 'fire' | 'controls' } | null;
+
 /** Top-level diagram state */
 export interface SldDiagramState {
   components: Record<string, SldComponentState>;
   wires: Record<string, SldWireState>;
+  /** Main-pane border overlay driven by `'Border'`-targeted alarms. */
+  border: SldBorderState;
   lastAlarmUpdate: string | null;
   dataAgeSeconds: number | null;
   dataStale: boolean;

--- a/src/components/SiteDefaultsPanel/SiteDefaultsPanel.tsx
+++ b/src/components/SiteDefaultsPanel/SiteDefaultsPanel.tsx
@@ -192,7 +192,7 @@ const FIELD_HELP: Record<string, string> = {
   capacity_kwh:
     'Total energy storage capacity. Used for the available-SoC duration warning.',
   ramp_duration_seconds:
-    'Time to ramp from 0 to full power. ConEd standard is 120 seconds (2-minute full-power ramp).',
+    'Time to ramp from 0 to full power. The utility standard is 120 seconds (2-minute full-power ramp).',
   closed_loop_enabled:
     'When on, scheduled commands are sent to the RTAC for execution. When off, schedules are visualized but not enforced.',
   charge_rate_percent:
@@ -280,8 +280,8 @@ const SiteDefaultsPanel: React.FC<SiteDefaultsPanelProps> = ({ onSavingChange, r
   /**
    * Live ramp-rate readout derived from the user's current power +
    * duration draft, surfaced inline so operators see what their config
-   * actually means in kW/minute (per-minute is the format ConEd uses
-   * when negotiating interconnection terms).
+   * actually means in kW/minute (per-minute is the format the utility
+   * uses when negotiating interconnection terms).
    *
    * Returns null when either input is empty or non-positive so the UI
    * can fall back to a generic helper line.
@@ -511,7 +511,7 @@ const SiteDefaultsPanel: React.FC<SiteDefaultsPanelProps> = ({ onSavingChange, r
                   : rampRateKwPerMin != null
                     ? `≈ ${Math.round(rampRateKwPerMin).toLocaleString()} kW/min ramp rate at current power.`
                     : autoRampDurationSeconds
-                      ? `Auto-suggested: ${autoRampDurationSeconds}s (matches ConEd 2-min full-power ramp).`
+                      ? `Auto-suggested: ${autoRampDurationSeconds}s (matches the utility's 2-min full-power ramp).`
                       : 'Time to ramp from 0 to full power. Default is 120s.'
               }
             />

--- a/src/pages/AlarmsPage.tsx
+++ b/src/pages/AlarmsPage.tsx
@@ -71,6 +71,8 @@ interface AlarmRow {
   zone: AlarmZoneDto;
   category: AlarmCategory;
   name: string;
+  /** Operator-facing message from the alarm spreadsheet; null when none. */
+  message: string | null;
   severity: AlarmSeverityDto;
   active: boolean;
   /** Number of activations in the last [HISTORY_WINDOW_DAYS] days. */
@@ -196,6 +198,7 @@ const AlarmsPage: React.FC = () => {
       zone: def.zone,
       category: getZoneCategory(def.zone),
       name: def.name,
+      message: def.message ?? null,
       severity: resolveAlarmSeverity(def.alarm_num, def.severity),
       active: activeNums.has(def.alarm_num),
       activations30d: activationCounts[def.alarm_num] ?? 0,
@@ -505,7 +508,14 @@ const AlarmsPage: React.FC = () => {
                       />
                     </TableCell>
                     <TableCell>{alarm.alarm_num}</TableCell>
-                    <TableCell>{formatAlarmName(alarm.name)}</TableCell>
+                    <TableCell>
+                      {formatAlarmName(alarm.name)}
+                      {alarm.message && (
+                        <Typography variant="caption" color="text.secondary" component="div">
+                          {alarm.message}
+                        </Typography>
+                      )}
+                    </TableCell>
                     <TableCell>{ZONE_DISPLAY_NAMES[alarm.zone]}</TableCell>
                     <TableCell>
                       <Chip

--- a/test/jest/tests/sld-page.test.ts
+++ b/test/jest/tests/sld-page.test.ts
@@ -25,7 +25,7 @@ describe('SLD Page Tests', () => {
 
   it('should render the project info card', async () => {
     const content = await page.content();
-    expect(content).toContain('Project Info: Brigis 1A');
+    expect(content).toContain('Project Info: Demo BESS 1A');
     expect(content).toContain('Address');
     expect(content).toContain('BESS Rating');
   });


### PR DESCRIPTION
## Summary

Renders active alarms on the **correct SLD element** with the **correct
message**, driven by the alarm metadata now served by the backend.

- **Targeting:** each component declares the "Related SLD Object" tokens it
  represents, so an alarm routes to the precise element (a relay fault to the
  relay, a `89L` open to that switch, a lockout to the lockout relay) instead of
  lighting every component sharing a zone. Tokens with no element yet (`Net`,
  `M1`/`M2`, `SST-UPS`, `CE_SCADA`) fall back to zone matching — no regression.
- **Message:** the operator message is shown in the SLD alarm popover and in the
  Alarms page table (falling back to the name when the spreadsheet has none).
- **Main-pane border:** a flashing frame for site-level faults (alarms targeting
  the `Border` object, plus a fire emergency in the FACP zone), colored by the
  highest severity among those alarms — matching the alarm-badge palette
  (Emergency red, Critical orange, Warning yellow, Info blue).
- Also scrubs a couple of residual utility names (`ConEd` → "the utility") in two
  SLD files and aligns an SLD page test with main's placeholder identity.

## Dependency / merge order

Consumes the `message` + `sld_targets` fields added in
**Newtown-Energy/neems-core#75**, and bumps `@newtown-energy/types` to **0.3.7**.
Merge neems-core#75 first so this builds against the published types.

## Verification

`tsc`, `eslint` (0 warnings), and the unit suite (42 tests, incl. new reducer
tests for targeting / message / border) all pass in-container.

## Follow-ups (not in this PR)

Dedicated SVG elements for the battery meters (`M1`/`M2`), RTAC sub-objects
(`CE_SCADA`/`SST-UPS`), and the network (`Net`) so those alarms get their own
target instead of the zone fallback.

Part of #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
