### PR TITLE
Unify alarm severity colors and fix chip legibility

### DIFF
--- a/src/components/SingleLineDiagram/elements/useStatusColors.ts
+++ b/src/components/SingleLineDiagram/elements/useStatusColors.ts
@@ -11,14 +11,11 @@ interface StatusColors {
 }
 
 /**
- * Severity-specific palette for SLD visuals. Deliberately chosen so each
- * severity reads distinctly at a glance:
- *   Emergency → bold red
- *   Critical  → bold orange
- *   Warning   → bold yellow
- *   Info      → blue
- * Deliberate hex values are used for orange/yellow rather than MUI's default
- * `warning` (which reads orangish) so Warning and Critical don't collide.
+ * Severity-specific palette for SLD visuals. Resolves to the canonical severity
+ * colors defined on the theme palette (see `theme.ts`), so SLD highlights,
+ * borders, and badges stay in lockstep with the severity Chips rendered via
+ * `getSeverityColor()`. Each severity reads distinctly at a glance:
+ *   Emergency → red, Critical → orange, Warning → yellow, Info → blue.
  */
 export function severityColor(
   severity: AlarmSeverityDto,
@@ -26,13 +23,13 @@ export function severityColor(
 ): string {
   switch (severity) {
     case 'Emergency':
-      return theme.palette.error.main;
+      return theme.palette.severityEmergency.main;
     case 'Critical':
-      return '#F57C00';
+      return theme.palette.severityCritical.main;
     case 'Warning':
-      return '#FFC107';
+      return theme.palette.severityWarning.main;
     case 'Info':
-      return theme.palette.info.main;
+      return theme.palette.severityInfo.main;
   }
 }
 

--- a/src/pages/SldPage.tsx
+++ b/src/pages/SldPage.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import {
   Alert,
   Box,
-  Chip,
   Paper,
   Stack,
   Typography,
@@ -101,13 +100,6 @@ const SldPage: React.FC = () => {
           No alarm data available yet. The diagram shows default (normal) state.
         </Alert>
       )}
-
-      <Stack direction="row" spacing={1} sx={{ mb: 2 }} flexWrap="wrap" useFlexGap>
-        <Chip label="Normal" size="small" variant="outlined" />
-        <Chip label="Warning" size="small" color="info" />
-        <Chip label="Critical" size="small" color="warning" />
-        <Chip label="Emergency" size="small" color="error" />
-      </Stack>
 
       <Box
         sx={{

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -105,20 +105,27 @@ export const theme = createTheme({
     // safety red from `error.main`; Critical/Warning use deliberate orange/yellow
     // hexes (MUI has no yellow named color) so Warning and Critical stay distinct;
     // Info is the standard MUI blue. Warning's yellow needs dark text for contrast.
+    // `dark` is a deeper shade used for outlined chips, where the vivid `main`
+    // (especially the yellow) is illegible as text/border on a light surface
+    // (see the MuiChip override below). Filled chips and the SLD keep `main`.
     severityEmergency: {
       main: '#D50000',
+      dark: '#9B0000',
       contrastText: '#FFFFFF',
     },
     severityCritical: {
       main: '#F57C00',
+      dark: '#E65100',
       contrastText: '#FFFFFF',
     },
     severityWarning: {
       main: '#FFC107',
+      dark: '#8C6D00',
       contrastText: 'rgba(0, 0, 0, 0.87)',
     },
     severityInfo: {
       main: '#0288D1',
+      dark: '#01579B',
       contrastText: '#FFFFFF',
     },
     background: {
@@ -145,6 +152,29 @@ export const theme = createTheme({
   },
   components: {
     ...baseTheme.components,
+    MuiChip: {
+      styleOverrides: {
+        // Outlined chips render their label and border in the chip color's
+        // `main`. The vivid severity yellow (and, to a lesser degree, orange)
+        // is hard to read as text on a light surface, so outlined severity
+        // chips fall back to the deeper `dark` shade. Filled chips are
+        // unaffected — they keep the vivid `main` fill with `contrastText`.
+        root: ({ ownerState, theme }) => {
+          const color = ownerState.color;
+          if (
+            ownerState.variant === 'outlined' &&
+            (color === 'severityEmergency' ||
+              color === 'severityCritical' ||
+              color === 'severityWarning' ||
+              color === 'severityInfo')
+          ) {
+            const dark = theme.palette[color].dark;
+            return { color: dark, borderColor: dark };
+          }
+          return {};
+        },
+      },
+    },
     MuiAppBar: {
       styleOverrides: {
         root: {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -2,6 +2,36 @@ import { createTheme } from '@mui/material/styles';
 import type { ThemeOptions } from '@mui/material/styles';
 import materialTheme from './material-theme.json';
 
+// Canonical alarm-severity palette — the single source of truth for severity
+// colors across the app (SLD component highlights, the main-pane border, alarm
+// badges, and every MUI severity Chip). Each severity reads distinctly at a
+// glance: Emergency → red, Critical → orange, Warning → yellow, Info → blue.
+// `severityColor()` (SLD SVG visuals) and `getSeverityColor()` (Chip color
+// prop) both resolve to these entries so the two never drift apart.
+declare module '@mui/material/styles' {
+  interface Palette {
+    severityEmergency: Palette['error'];
+    severityCritical: Palette['error'];
+    severityWarning: Palette['error'];
+    severityInfo: Palette['error'];
+  }
+  interface PaletteOptions {
+    severityEmergency?: PaletteOptions['error'];
+    severityCritical?: PaletteOptions['error'];
+    severityWarning?: PaletteOptions['error'];
+    severityInfo?: PaletteOptions['error'];
+  }
+}
+
+declare module '@mui/material/Chip' {
+  interface ChipPropsColorOverrides {
+    severityEmergency: true;
+    severityCritical: true;
+    severityWarning: true;
+    severityInfo: true;
+  }
+}
+
 const baseTheme: ThemeOptions = {
   typography: {
     fontFamily: '"Inter", "Segoe UI", "Roboto", "Helvetica", "Arial", sans-serif',
@@ -69,6 +99,26 @@ export const theme = createTheme({
       main: '#D50000',
       light: '#FF5131',
       dark: '#9B0000',
+      contrastText: '#FFFFFF',
+    },
+    // Severity palette — see the module augmentation above. Emergency reuses the
+    // safety red from `error.main`; Critical/Warning use deliberate orange/yellow
+    // hexes (MUI has no yellow named color) so Warning and Critical stay distinct;
+    // Info is the standard MUI blue. Warning's yellow needs dark text for contrast.
+    severityEmergency: {
+      main: '#D50000',
+      contrastText: '#FFFFFF',
+    },
+    severityCritical: {
+      main: '#F57C00',
+      contrastText: '#FFFFFF',
+    },
+    severityWarning: {
+      main: '#FFC107',
+      contrastText: 'rgba(0, 0, 0, 0.87)',
+    },
+    severityInfo: {
+      main: '#0288D1',
       contrastText: '#FFFFFF',
     },
     background: {

--- a/src/utils/alarmHelpers.ts
+++ b/src/utils/alarmHelpers.ts
@@ -24,19 +24,24 @@ export function formatAlarmName(name: string): string {
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-/** Get MUI color for alarm severity */
+/**
+ * MUI Chip `color` for an alarm severity. Returns custom theme palette colors
+ * (registered in `theme.ts`) so severity Chips match the SLD palette exactly:
+ *   Emergency → red, Critical → orange, Warning → yellow, Info → blue.
+ * These resolve to the same hexes as `severityColor()` used for SLD visuals.
+ */
 export function getSeverityColor(
   severity: AlarmSeverityDto,
-): 'error' | 'warning' | 'info' | 'success' {
+): 'severityEmergency' | 'severityCritical' | 'severityWarning' | 'severityInfo' {
   switch (severity) {
     case 'Emergency':
-      return 'error';
+      return 'severityEmergency';
     case 'Critical':
-      return 'warning';
+      return 'severityCritical';
     case 'Warning':
-      return 'info';
+      return 'severityWarning';
     case 'Info':
-      return 'success';
+      return 'severityInfo';
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes a severity-color mismatch on the SLD and aligns severity colors everywhere they surface.

Previously two divergent functions drove severity colors:
- `severityColor()` (SLD highlights, main-pane border, alarm badge) → red / orange / yellow / blue
- `getSeverityColor()` (MUI severity chips) → a shifted mapping that rendered **Warning as blue** and **Info as green**

So a Warning alarm showed a yellow triangle on the SLD but a blue chip in its popover.

## Changes

- **Single source of truth in the theme** (`theme.ts`): added canonical `severity*` palette colors — Emergency red, Critical orange, Warning yellow, Info blue — plus MUI module augmentation so `<Chip color="severity…">` is type-valid.
- **Both color functions now resolve to the palette**, so the SLD, border, badges, and every severity chip (Alarms, Overview, FDNY, Demo-controls) stay in lockstep.
- **Outlined chip legibility**: added a deeper `dark` shade per severity and a `MuiChip` override so outlined chips (e.g. the "N Warning" filter pills) use `dark` for text/border — the vivid yellow `main` was illegible on a light surface. Filled chips and the SLD keep the vivid `main`.
- **Removed the SLD severity legend** on `SldPage`, which used the old shifted colors; the badges/border already convey severity by color and shape.

## Note

This also corrects `Info` chips, which previously rendered **green** — they're now blue, consistent with the SLD.

## Testing

- `bun run lint:tsc` — clean
- `bun run test:unit` — 42 pass
- Worth a quick visual check of the Alarms page severity pills when running the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)