### PR TITLE
Add demo CD for the web front end (Actions → GHCR → DO App)

### DIFF
--- a/.do/README.md
+++ b/.do/README.md
@@ -1,0 +1,47 @@
+# Demo deployment (DigitalOcean App Platform)
+
+This repo continuously deploys the public **demo web front end** to its own
+DigitalOcean App — no coordinator repo. GitHub Actions builds the image and
+pushes it to public GHCR (`ghcr.io/newtown-energy/neems-web`); on merge to
+`main`, `.github/workflows/deploy.yml` rolls the App via
+`doctl apps create-deployment`. It also builds the image on PRs as a check.
+
+Caddy serves the built SPA and reverse-proxies `/api` to the **separate core
+API App** (`neems-core`), so the browser sees one origin and the `SameSite=Lax`
+session cookie works. Keep both Apps on one registrable domain — same-origin or
+sibling subdomains (`app.demo.x` / `api.demo.x`), never fully cross-site.
+
+## One-time setup
+
+1. Make the `neems-web` GHCR package **public** (GitHub → org **Packages** →
+   `neems-web` → **Package settings** → Public) so App Platform can pull it with
+   no credential. The package appears after the first image push (first merge to
+   `main`).
+2. Create the App:
+   ```bash
+   doctl apps create --spec .do/app.yaml
+   doctl apps list        # note the App id + the *.ondigitalocean.app URL
+   ```
+3. Set **`NEEMS_API_UPSTREAM`** as an env var **on the App** (dashboard or
+   `doctl`) — it is deliberately not committed to the spec, so it's configured
+   per-deployment rather than hard-coded. Point it at the core API App's public
+   URL — its `*.ondigitalocean.app` address or `api.demo.x` — **including
+   `https://`**, e.g. `https://neems-demo-api-xxxx.ondigitalocean.app`. (Until
+   it's set, the App serves the SPA fine but `/api` calls won't resolve.)
+4. Add repo secrets: `DIGITALOCEAN_ACCESS_TOKEN` (must be **write**-capable —
+   `create-deployment` is a write op) and `DIGITALOCEAN_APP_ID` (this App's id).
+
+After this, every merge to `main` rebuilds and redeploys.
+
+## Notes
+
+- App Platform serves the App over HTTPS (edge TLS); Caddy runs plain HTTP
+  internally (`DEMO_DOMAIN=:80`, HTTP port 80).
+- Routine CD uses `doctl apps create-deployment`, which redeploys with the App's
+  **stored** config — so `NEEMS_API_UPSTREAM` set on the App persists and is not
+  overwritten by CI.
+- `instance_size_slug` is a starting guess; confirm with
+  `doctl apps tier instance-size list`.
+- To change the spec, edit `.do/app.yaml` and
+  `doctl apps update <id> --spec .do/app.yaml` (re-set `NEEMS_API_UPSTREAM`
+  after, since the committed value is a placeholder).

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,0 +1,46 @@
+# DigitalOcean App Platform spec for the public NEEMS demo web front end.
+#
+# Built in GitHub Actions and pushed to public GHCR (ghcr.io/newtown-energy/
+# neems-web); this App pulls the image and App Platform serves it over HTTPS.
+# Self-contained CD — no coordinator repo (see .github/workflows/deploy.yml).
+#
+# Caddy serves the built SPA and reverse-proxies /api to the SEPARATE core API
+# App (neems-core), so the browser stays same-origin and the SameSite=Lax
+# session cookie keeps working. Set NEEMS_API_UPSTREAM to the core App's public
+# URL. Keep both Apps on one registrable domain (same-origin or sibling
+# subdomains like app.demo.x / api.demo.x), never fully cross-site.
+#
+# Routine CD uses `doctl apps create-deployment` (re-pull :latest), so this
+# committed spec is the bootstrap template + reference; the live App is the
+# source of truth for NEEMS_API_UPSTREAM. See .do/README.md.
+
+name: neems-demo-web
+region: nyc
+
+services:
+  - name: web
+    image:
+      registry_type: GHCR
+      registry: newtown-energy
+      repository: neems-web
+      tag: latest
+      # Public GHCR package -> no pull credential. If you make it private, add:
+      #   registry_credentials: "<gh-user>:<read:packages PAT>"
+    http_port: 80
+    # Adjust to a current slug from `doctl apps tier instance-size list`.
+    instance_size_slug: apps-s-1vcpu-0.5gb
+    instance_count: 1
+    routes:
+      - path: /
+    health_check:
+      http_path: /
+    envs:
+      # App Platform terminates TLS at the edge; Caddy serves plain HTTP.
+      - key: DEMO_DOMAIN
+        value: ":80"
+      # NEEMS_API_UPSTREAM (the core API App's public URL that Caddy proxies
+      # /api to) is intentionally NOT set here — configure it on the App in
+      # DigitalOcean so it isn't hard-coded in git. Set it to the core App's
+      # public URL, including the https:// scheme, once that App is up. Until
+      # then Caddy falls back to neems-api:8000 and /api won't resolve. See
+      # .do/README.md.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# node_modules and dist are regenerated inside the build; keeping them out of
+# the context avoids leaking host state and speeds the build.
+node_modules/
+dist/
+.git/
+local-types/
+test/jest/node_modules/
+**/*.swp
+.DS_Store

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,93 @@
+name: Demo CD
+
+# Self-contained continuous deployment for this repo's public demo web App on
+# DigitalOcean App Platform. No coordinator repo — neems-react owns and deploys
+# its own App.
+#
+#   - pull request  -> build the image as a check (no push, no deploy)
+#   - merge to main  -> push ghcr.io/newtown-energy/neems-web, then roll a new
+#                       deployment of the demo web App (re-pulls :latest)
+#
+# The demo App is the ONLY environment fed by CI. Production sites are
+# air-gapped, behind a VPN, and updated by hand — never touched here.
+#
+# Required repo secrets (beyond the automatic GITHUB_TOKEN, which pushes to GHCR
+# and installs the @newtown-energy/types package):
+#   DIGITALOCEAN_ACCESS_TOKEN - DO API token (App read + write)
+#   DIGITALOCEAN_APP_ID       - id of the demo web App (`doctl apps list`)
+# One-time setup: see .do/README.md.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths:
+      - 'Dockerfile.demo'
+      - '.dockerignore'
+      - 'deploy/Caddyfile'
+      - 'src/**'
+      - 'public/**'
+      - 'index.html'
+      - 'package.json'
+      - 'bun.lock'
+      - 'tsconfig*.json'
+      - 'vite.config.ts'
+      - '.do/**'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/newtown-energy/neems-web
+
+jobs:
+  build:
+    name: Build image${{ github.event_name == 'pull_request' && ' (check)' || ' and push' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build (and push on main)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.demo
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+          # @newtown-energy/types is a public GitHub Packages package; the
+          # automatic GITHUB_TOKEN has packages:read to install it.
+          secrets: |
+            github_packages_token=${{ secrets.GITHUB_TOKEN }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy demo web App
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      # Roll a new deployment that re-pulls the :latest image. Uses the App's
+      # stored config (incl. NEEMS_API_UPSTREAM), so CI never overwrites it.
+      - name: Roll a new deployment
+        run: doctl apps create-deployment "${{ secrets.DIGITALOCEAN_APP_ID }}" --wait

--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -1,0 +1,28 @@
+# Demo image for the NEEMS web front end (production/release build).
+#
+# The dev Dockerfile runs the Vite dev server (for HMR + the /api proxy). This
+# one builds the static bundle and serves it with Caddy, which also terminates
+# TLS and reverse-proxies /api to the backend so the app and API share a single
+# origin (required by the Secure; SameSite=Lax session cookie).
+
+# ---- build stage ------------------------------------------------------------
+FROM oven/bun:1 AS builder
+WORKDIR /app
+
+# .npmrc routes the @newtown-energy scope to GitHub Packages and reads the auth
+# token from $GITHUB_PACKAGES_TOKEN. The token is provided as a BuildKit secret
+# so it never lands in an image layer. With no local-types/ present, the build
+# resolves @newtown-energy/types to the published package.
+COPY package.json bun.lock .npmrc ./
+RUN --mount=type=secret,id=github_packages_token \
+    GITHUB_PACKAGES_TOKEN="$(cat /run/secrets/github_packages_token 2>/dev/null)" \
+    bun install --frozen-lockfile
+
+COPY . .
+RUN bun run build   # -> /app/dist
+
+# ---- runtime stage ----------------------------------------------------------
+FROM caddy:2-alpine AS runtime
+COPY --from=builder /app/dist /srv
+COPY deploy/Caddyfile /etc/caddy/Caddyfile
+EXPOSE 80 443

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,37 @@
+# Caddy config baked into the neems-web image (Dockerfile.demo).
+#
+# DEMO_DOMAIN controls the site address:
+#   - a real hostname (e.g. demo.example.org) -> automatic HTTPS via ACME
+#   - ":80"                                   -> plain HTTP (App Platform does TLS)
+#
+# NEEMS_API_UPSTREAM is the address Caddy proxies /api to. It is set as an
+# environment variable on THIS App in DigitalOcean (not hard-coded) — point it
+# at the core API App's public URL, including the scheme, e.g.
+# https://neems-demo-api-xxxx.ondigitalocean.app. Falls back to neems-api:8000
+# for local/compose use when unset.
+
+{$DEMO_DOMAIN::80} {
+	encode gzip
+
+	# API traffic is reverse-proxied to the backend. Same origin as the app,
+	# so the SameSite=Lax session cookie is sent normally.
+	handle /api/* {
+		reverse_proxy {$NEEMS_API_UPSTREAM:neems-api:8000} {
+			header_up X-Forwarded-Proto {scheme}
+			header_up X-Real-IP {remote_host}
+		}
+	}
+
+	# Everything else is the single-page app. Unknown paths fall back to
+	# index.html so client-side routes survive a hard refresh / deep link.
+	handle {
+		root * /srv
+		try_files {path} /index.html
+		file_server
+		header {
+			X-Frame-Options DENY
+			X-Content-Type-Options nosniff
+			Referrer-Policy strict-origin-when-cross-origin
+		}
+	}
+}


### PR DESCRIPTION
Parallel to neems-core's demo CD — a self-contained pipeline that deploys this repo's public **demo web front end** to its own DigitalOcean App. No coordinator repo, no DO GitHub App.

**Model:** on merge to `main`, Actions builds `Dockerfile.demo` and pushes `ghcr.io/newtown-energy/neems-web:latest` (public), then `doctl apps create-deployment` rolls the App. PRs build the image as a check.

**What's here:**
- **`Dockerfile.demo`** — Bun build of the SPA, served by **Caddy** (static + SPA fallback + `/api` reverse-proxy).
- **`deploy/Caddyfile`** — proxies `/api` to the core API App so the browser stays same-origin (`SameSite=Lax` cookie works).
- **`.do/app.yaml`** — the demo web App (single public Caddy service from the GHCR image).
- **`.github/workflows/deploy.yml`** — PR build check; on `main`, build + push + `doctl` deploy.
- **`.do/README.md`** — one-time setup.

**`NEEMS_API_UPSTREAM` is configured on the App in DigitalOcean, not committed** — set it to the core API App's public URL (incl. `https://`) once that App is up. Until then the SPA serves fine and `/api` is inert.

**Topology:** a separate App from the core API; Caddy proxies `/api` to the core App over its public HTTPS URL, so everything is one origin from the browser. Keep both Apps on one registrable domain (same-origin or sibling subdomains).

**Required repo secrets:** `DIGITALOCEAN_ACCESS_TOKEN` (write-capable) + `DIGITALOCEAN_APP_ID` (plus the automatic `GITHUB_TOKEN` for GHCR push and installing `@newtown-energy/types`).

Verified: workflow + App spec YAML validate; the image build runs as this PR's check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
