### PR TITLE
Serve the web App on 8080 (App Platform default port)

### DIFF
--- a/.do/README.md
+++ b/.do/README.md
@@ -36,7 +36,7 @@ After this, every merge to `main` rebuilds and redeploys.
 ## Notes
 
 - App Platform serves the App over HTTPS (edge TLS); Caddy runs plain HTTP
-  internally (`DEMO_DOMAIN=:80`, HTTP port 80).
+  internally on App Platform's default port (`DEMO_DOMAIN=:8080`, HTTP port 8080).
 - Routine CD uses `doctl apps create-deployment`, which redeploys with the App's
   **stored** config — so `NEEMS_API_UPSTREAM` set on the App persists and is not
   overwritten by CI.

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -26,7 +26,7 @@ services:
       tag: latest
       # Public GHCR package -> no pull credential. If you make it private, add:
       #   registry_credentials: "<gh-user>:<read:packages PAT>"
-    http_port: 80
+    http_port: 8080
     # Adjust to a current slug from `doctl apps tier instance-size list`.
     instance_size_slug: apps-s-1vcpu-0.5gb
     instance_count: 1
@@ -35,9 +35,10 @@ services:
     health_check:
       http_path: /
     envs:
-      # App Platform terminates TLS at the edge; Caddy serves plain HTTP.
+      # App Platform terminates TLS at the edge; Caddy serves plain HTTP on
+      # App Platform's default port (8080), matching http_port above.
       - key: DEMO_DOMAIN
-        value: ":80"
+        value: ":8080"
       # NEEMS_API_UPSTREAM (the core API App's public URL that Caddy proxies
       # /api to) is intentionally NOT set here — configure it on the App in
       # DigitalOcean so it isn't hard-coded in git. Set it to the core App's

--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -25,4 +25,6 @@ RUN bun run build   # -> /app/dist
 FROM caddy:2-alpine AS runtime
 COPY --from=builder /app/dist /srv
 COPY deploy/Caddyfile /etc/caddy/Caddyfile
-EXPOSE 80 443
+# Caddy listens on 8080 (App Platform's default port); DO terminates TLS at the
+# edge, so Caddy serves plain HTTP and never binds 443 itself.
+EXPOSE 8080

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -2,7 +2,8 @@
 #
 # DEMO_DOMAIN controls the site address:
 #   - a real hostname (e.g. demo.example.org) -> automatic HTTPS via ACME
-#   - ":80"                                   -> plain HTTP (App Platform does TLS)
+#   - ":8080"                                 -> plain HTTP (App Platform does TLS);
+#                                                8080 is App Platform's default port
 #
 # NEEMS_API_UPSTREAM is the address Caddy proxies /api to. It is set as an
 # environment variable on THIS App in DigitalOcean (not hard-coded) — point it
@@ -10,7 +11,7 @@
 # https://neems-demo-api-xxxx.ondigitalocean.app. Falls back to neems-api:8000
 # for local/compose use when unset.
 
-{$DEMO_DOMAIN::80} {
+{$DEMO_DOMAIN::8080} {
 	encode gzip
 
 	# API traffic is reverse-proxied to the backend. Same origin as the app,


### PR DESCRIPTION
Follow-up to #92. App Platform's default component `http_port` is **8080**, so align the web App to it:

- `deploy/Caddyfile` — Caddy listens on `:8080` (`DEMO_DOMAIN` default).
- `.do/app.yaml` — `http_port: 8080`, `DEMO_DOMAIN=:8080`.
- `Dockerfile.demo` — `EXPOSE 8080`; drop the vestigial `443` (DO terminates TLS at the edge, so Caddy only serves plain HTTP and never binds 443).

Using DO's default port means the App works whether it's created from the spec **or** the dashboard — avoiding the port-mismatch that the core API App hit (probe on `:8080` vs app on the other port). The public URL is unaffected: users still reach it over HTTPS on 443; 8080 is only the internal container port DO's edge forwards to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)