### PR TITLE
Group Dependabot GitHub Action bumps into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # One PR per week for all Action bumps rather than one PR per Action.
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Groups all `github-actions` updates into a single weekly Dependabot PR instead of one PR per Action.

Action bumps have been arriving one PR at a time, each needing its own review and full CI run for a one-line version change.

```yaml
    groups:
      github-actions:
        patterns:
          - "*"
```

Dependabot still opens a separate PR for anything it cannot group, so nothing is silently dropped — grouping changes how updates are batched, not whether they are surfaced.

Schedule is unchanged (weekly). Matching change in neems-core: Newtown-Energy/neems-core#88.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MBhtRfWpUbJAY1rH9Euwf
