### PR TITLE
Fail the deploy when the App id secret is missing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,5 +89,16 @@ jobs:
 
       # Roll a new deployment that re-pulls the :latest image. Uses the App's
       # stored config (incl. NEEMS_API_UPSTREAM), so CI never overwrites it.
+      #
+      # An unset secret interpolates to an empty string rather than failing, so
+      # a missing APP_ID would otherwise reach the API as `/v2/apps//deployments`
+      # and come back as an opaque 405. Check it first and say what is wrong.
       - name: Roll a new deployment
-        run: doctl apps create-deployment "${{ secrets.DIGITALOCEAN_APP_ID }}" --wait
+        env:
+          APP_ID: ${{ secrets.DIGITALOCEAN_APP_ID }}
+        run: |
+          if [ -z "$APP_ID" ]; then
+            echo "::error::DIGITALOCEAN_APP_ID is not set. Add it as a repo secret (see .do/README.md)."
+            exit 1
+          fi
+          doctl apps create-deployment "$APP_ID" --wait


### PR DESCRIPTION
Makes the demo deploy fail with a readable message when `DIGITALOCEAN_APP_ID` is unset.

**This repo's secret is fine today** — `DIGITALOCEAN_APP_ID` is set and the workflow already references the correct name. This is preventative, prompted by neems-core hitting the failure for real.

GitHub interpolates an **unset secret to an empty string** rather than failing. In neems-core the secret was renamed in repo settings while the workflow still used the old name, so `doctl` was handed `""`, built `POST /v2/apps//deployments`, and DigitalOcean answered an opaque `405`. The image build had already succeeded, so only the deploy step went red — with nothing in the step name or error to indicate a missing secret.

```yaml
      - name: Roll a new deployment
        env:
          APP_ID: ${{ secrets.DIGITALOCEAN_APP_ID }}
        run: |
          if [ -z "$APP_ID" ]; then
            echo "::error::DIGITALOCEAN_APP_ID is not set. Add it as a repo secret (see .do/README.md)."
            exit 1
          fi
          doctl apps create-deployment "$APP_ID" --wait
```

`::error::` surfaces it as a GitHub annotation rather than a line buried in the log. Passing the value via `env:` instead of interpolating it directly into `run:` also keeps it out of the generated script body.

Validated with `actionlint` (which also shellchecks `run:` blocks) — clean.

Same change in neems-core: Newtown-Energy/neems-core#80.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MBhtRfWpUbJAY1rH9Euwf
