### PR TITLE
Stack the transformer's grounding symbols

### DIFF
--- a/src/components/SingleLineDiagram/elements/Transformer.tsx
+++ b/src/components/SingleLineDiagram/elements/Transformer.tsx
@@ -29,9 +29,9 @@ function windingPath(y0: number, loops: number, r: number, dir: number): string 
  * Transformer: the conventional two-winding symbol — two rows of semicircular
  * coil lobes (primary above, secondary below) whose convex faces meet across
  * the central gap, with the open side of each lobe facing outward. The vertical
- * conductor connects to each winding's baseline. Two wye (star) marks sit side
- * by side beside the windings to indicate the site's Y/Y winding configuration
- * (high side and low side).
+ * conductor connects to each winding's baseline. Two wye (star) marks stack
+ * vertically beside the windings to indicate the site's Y/Y winding
+ * configuration, the upper mark for the high side and the lower for the low.
  */
 const Transformer: React.FC<SldElementProps> = ({ x, y, state, label }) => {
   const theme = useTheme();
@@ -79,9 +79,12 @@ const Transformer: React.FC<SldElementProps> = ({ x, y, state, label }) => {
       <line x1={0} y1={secondaryBaseline} x2={0} y2={stubBottomY} stroke={lineColor} strokeWidth={2} />
       <circle cx={0} cy={stubBottomY} r={2} fill={lineColor} />
 
-      {/* Wye (star) + down-arrow marks, side by side beside the windings */}
-      <WyeSymbol x={halfW + 7} y={-2} color={lineColor} scale={0.55} />
-      <WyeSymbol x={halfW + 18} y={-2} color={lineColor} scale={0.55} />
+      {/* Wye (star) + down-arrow marks, stacked vertically beside the windings:
+          high side above, low side below. Each mark reaches 9*scale above its
+          junction and 16*scale below it, so the two junctions sit 16 apart to
+          keep the upper mark's lead arrow clear of the lower mark's spokes. */}
+      <WyeSymbol x={halfW + 8} y={-10} color={lineColor} scale={0.55} />
+      <WyeSymbol x={halfW + 8} y={6} color={lineColor} scale={0.55} />
 
       {/* Label */}
       {label && (


### PR DESCRIPTION
Closes #106.

The two grounded-wye marks beside the transformer coils annotate the
site's Y/Y winding configuration — one for the high side, one for the
low. They were drawn side by side, which reads as an unrelated pair
rather than as one mark per winding. Product owner asked for them
stacked.

They now share an `x` and sit 16 apart in `y`, which is more than the
symbol's own height (`9*scale` above its junction plus `16*scale`
below), so the upper mark's neutral lead arrow clears the lower mark's
spokes. The pair is centered on the winding block. Applies to both T1
and T2, which share the component.

Verified by rendering the SLD page headless and cropping T1:

```
              |
   T1  ⌒⌒⌒⌒   ⏚
       ⌣⌣⌣⌣   ⏚
              |
```

Unit tests pass (53/53). `lint:eslint` reports the usual pre-existing
`is an 'error' type` failures from the `local-types` bind mount; none of
them are in the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Session: db297b27-d6cf-401c-8867-def4289698d6
