### PR TITLE
Show live analog values on the SLD

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "recharts": "^3.8.1",
       },
       "devDependencies": {
-        "@newtown-energy/types": "0.5.0",
+        "@newtown-energy/types": "0.6.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.0.10",
         "@types/react": "^19.1.8",
@@ -331,7 +331,7 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
-    "@newtown-energy/types": ["@newtown-energy/types@0.5.0", "https://npm.pkg.github.com/download/@newtown-energy/types/0.5.0/0e08b77c11eed46522226a12c83529d812c0811d", {}, "sha512-8wicly/YXDN0G6hKeH0W3vvs0/zfQSRwhNh9HOnsP0lZGhGjUEd2CbzB7jj75uhWV1V6J4u7ntzjo4fPKET+jg=="],
+    "@newtown-energy/types": ["@newtown-energy/types@0.6.0", "https://npm.pkg.github.com/download/@newtown-energy/types/0.6.0/0eda1d450bee1ecd32dfd30b8ea79b8b3d517fda", {}, "sha512-wVPo77NdsTE9mNpBz02M2GQuuIRyI2sZSJoAUYhe10SLqww78FqqO/CevzxW0kbjZb62IfDiDD0PW2foAf8pWA=="],
 
     "@parcel/watcher": ["@parcel/watcher@2.5.6", "", { "dependencies": { "detect-libc": "^2.0.3", "is-glob": "^4.0.3", "node-addon-api": "^7.0.0", "picomatch": "^4.0.3" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.6", "@parcel/watcher-darwin-arm64": "2.5.6", "@parcel/watcher-darwin-x64": "2.5.6", "@parcel/watcher-freebsd-x64": "2.5.6", "@parcel/watcher-linux-arm-glibc": "2.5.6", "@parcel/watcher-linux-arm-musl": "2.5.6", "@parcel/watcher-linux-arm64-glibc": "2.5.6", "@parcel/watcher-linux-arm64-musl": "2.5.6", "@parcel/watcher-linux-x64-glibc": "2.5.6", "@parcel/watcher-linux-x64-musl": "2.5.6", "@parcel/watcher-win32-arm64": "2.5.6", "@parcel/watcher-win32-ia32": "2.5.6", "@parcel/watcher-win32-x64": "2.5.6" } }, "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "recharts": "^3.8.1"
   },
   "devDependencies": {
-    "@newtown-energy/types": "0.5.0",
+    "@newtown-energy/types": "0.6.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.0.10",
     "@types/react": "^19.1.8",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "npm run lint:eslint && npm run lint:tsc",
     "lint:eslint": "eslint ./src --max-warnings=0",
-    "lint:tsc": "tsc --noEmit",
+    "lint:tsc": "tsc -b",
     "test:unit": "bun test src",
     "preview": "vite preview",
     "generate-types": "dosh generate-types"

--- a/src/components/SingleLineDiagram/SingleLineDiagram.tsx
+++ b/src/components/SingleLineDiagram/SingleLineDiagram.tsx
@@ -27,9 +27,11 @@ import {
 import type { SldAction } from './sldState';
 import type { SldDiagramState } from './types';
 import { useSldAlarms } from './useSldAlarms';
+import { useSldAnalogs } from './useSldAnalogs';
 import type { EstopState } from '../../utils/useEstop';
 import { SldAlarmRefetchContext } from './SldAlarmRefetchContext';
 import NewtownLayout from './layouts/NewtownLayout';
+import { useSiteContext } from '../../utils/SiteContext';
 import CurtailmentBadge from './CurtailmentBadge';
 
 const DIAGRAM_WIDTH = 1200;
@@ -124,6 +126,7 @@ const SingleLineDiagram: React.FC<SingleLineDiagramProps> = ({
   estop,
 }) => {
   const [state, dispatch] = useReducer(sldReducer, INITIAL_STATE);
+  const { selectedSite } = useSiteContext();
   const [eStopDialogOpen, setEStopDialogOpen] = useState(false);
   const theme = useTheme();
 
@@ -171,6 +174,11 @@ const SingleLineDiagram: React.FC<SingleLineDiagramProps> = ({
   // polling on in demoMode is safe and lets forced alarms surface
   // through the same path real alarms use.
   const { refetch: refetchAlarms } = useSldAlarms(dispatch);
+
+  // Gauge values, on the same cadence as the alarm poll. Separate from it
+  // because the two answer different questions and a site with no analog
+  // feed must still light its alarms.
+  useSldAnalogs(dispatch, selectedSite?.id ?? null);
 
   useEffect(() => {
     onDispatchReady?.(dispatch);

--- a/src/components/SingleLineDiagram/elements/BusBar.tsx
+++ b/src/components/SingleLineDiagram/elements/BusBar.tsx
@@ -33,6 +33,7 @@ const BusBar: React.FC<BusBarProps> = ({
     ? theme.palette.text.primary
     : theme.palette.action.disabled;
   const nodeColor = theme.palette.info.main;
+  const uniqueNodes = Array.from(new Set(nodes ?? []));
 
   return (
     <>
@@ -52,8 +53,11 @@ const BusBar: React.FC<BusBarProps> = ({
           </text>
         )}
       </g>
-      {/* Node dots in absolute coords (nodes array is in the caller's space) */}
-      {nodes?.map((nx) => (
+      {/* Node dots in absolute coords (nodes array is in the caller's space).
+          De-duplicated: a switch drop and a feeder can share an x (390 on bus
+          1, 870 on bus 2), and a junction dot is idempotent -- drawing it
+          twice paints the same pixels and collides the React key. */}
+      {uniqueNodes.map((nx) => (
         <circle
           key={`bus-node-${nx}`}
           cx={nx}

--- a/src/components/SingleLineDiagram/elements/Megapack.tsx
+++ b/src/components/SingleLineDiagram/elements/Megapack.tsx
@@ -5,6 +5,7 @@ import { useStatusColors } from './useStatusColors';
 import AlarmIndicator from './AlarmIndicator';
 import AlarmGlow from './AlarmGlow';
 import { SLD_FONT } from '../sldTypography';
+import { gaugeFill, gaugeGeometry } from './chargeGauge';
 
 const FIRE_RELATED_KEYWORDS = ['high temp', 'hi temp', 'sparker', 'fire'];
 
@@ -56,6 +57,11 @@ const Megapack: React.FC<SldElementProps> = ({ x, y, state, label }) => {
   const stackTemp = state.analogs?.stackTemp ?? null;
   const outputV = state.analogs?.outputVoltage ?? null;
 
+  // `gaugeLevel`, not `fill`: `fill` is already the body's status color from
+  // useStatusColors above.
+  const gauge = gaugeGeometry(w, h);
+  const gaugeLevel = gaugeFill(soc, gauge);
+
   return (
     <g transform={`translate(${x}, ${y})`}>
       {/* Pulsing severity glow — rendered behind the body for Emergency/Critical */}
@@ -73,26 +79,38 @@ const Megapack: React.FC<SldElementProps> = ({ x, y, state, label }) => {
         strokeWidth={strokeWidth}
         rx={2}
       />
-      {/* Charge bar graph — vertical fill proportional to SOC%.
-          Rendered behind the fan circles. Clamped to [0, 100]. */}
-      {soc != null && !Number.isNaN(soc) && (() => {
-        const pct = Math.max(0, Math.min(100, soc));
-        const innerW = w - 4;
-        const innerH = h - 4;
-        const barH = (pct / 100) * innerH;
-        const barY = h / 2 - 2 - barH;
-        return (
+      {/* Charge gauge — the spreadsheet's "MP gas gauge".
+          An inset bordered track rather than a tint over the whole body: the
+          body's fill and AlarmGlow already encode alarm state, and a
+          measurement painted on the same rect competes with them. Giving
+          charge its own bordered channel lets an operator read level and
+          alarm independently.
+          Drawn only when there is a reading. An empty track is
+          indistinguishable from an empty pack, and those are opposite
+          claims — no reading shows no gauge, matching the `--` in the text
+          below. */}
+      {gaugeLevel && (
+        <g>
           <rect
-            x={-w / 2 + 2}
-            y={barY}
-            width={innerW}
-            height={barH}
-            fill={theme.palette.success.main}
-            opacity={0.3}
+            x={gauge.x}
+            y={gauge.y}
+            width={gauge.width}
+            height={gauge.height}
+            fill="none"
+            stroke={lineColor}
+            strokeWidth={0.75}
+            opacity={0.7}
             rx={1}
           />
-        );
-      })()}
+          <rect
+            x={gaugeLevel.x}
+            y={gaugeLevel.y}
+            width={gaugeLevel.width}
+            height={gaugeLevel.height}
+            fill={theme.palette.success.main}
+          />
+        </g>
+      )}
       {/* Five stack-fan circles (back-panel indicators) */}
       {Array.from({ length: fanCount }).map((_, i) => {
         const cy = fanYStart + i * fanSpacing;

--- a/src/components/SingleLineDiagram/elements/Megapack.tsx
+++ b/src/components/SingleLineDiagram/elements/Megapack.tsx
@@ -23,6 +23,20 @@ function formatAnalog(value: number | null | undefined, unit: string): string {
 }
 
 /**
+ * Real power, labelled by what the pack is doing rather than by sign alone.
+ *
+ * Negative is charging — the pack is a load — which is the convention the
+ * backend reads off the register. A bare "-950 kW" makes an operator remember
+ * that; the word does not.
+ */
+function formatPower(kW: number | null | undefined): string {
+  if (kW == null || Number.isNaN(kW)) return '-- kW';
+  if (kW === 0) return 'idle';
+  const verb = kW < 0 ? 'chg' : 'dis';
+  return `${verb} ${Math.abs(kW).toFixed(0)} kW`;
+}
+
+/**
  * Megapack 2XL battery unit.
  * Shape: a tall rectangle with five small circles stacked along its right side
  * (representing the stack "fans"/vents on the back panel).
@@ -56,11 +70,22 @@ const Megapack: React.FC<SldElementProps> = ({ x, y, state, label }) => {
   const soc = state.analogs?.soc ?? null;
   const stackTemp = state.analogs?.stackTemp ?? null;
   const outputV = state.analogs?.outputVoltage ?? null;
+  const realPower = state.analogs?.real_power_output ?? null;
 
   // `gaugeLevel`, not `fill`: `fill` is already the body's status color from
   // useStatusColors above.
   const gauge = gaugeGeometry(w, h);
   const gaugeLevel = gaugeFill(soc, gauge);
+
+  // Charging and discharging are the two states an operator is actually
+  // looking for, so they get a color as well as a sign. Idle and unknown stay
+  // in the secondary text color, because neither is an event.
+  const powerColor =
+    realPower == null || Number.isNaN(realPower) || realPower === 0
+      ? theme.palette.text.secondary
+      : realPower < 0
+        ? theme.palette.info.main
+        : theme.palette.warning.main;
 
   return (
     <g transform={`translate(${x}, ${y})`}>
@@ -183,6 +208,19 @@ const Megapack: React.FC<SldElementProps> = ({ x, y, state, label }) => {
           fill={theme.palette.text.secondary}
         >
           V {formatAnalog(outputV, 'V')}
+        </text>
+        {/* Real power, signed: the sign is the reading. A pack pulling
+            1,000 kW in and one pushing 1,000 kW out are opposite states that
+            an unsigned magnitude would render identically. */}
+        <text
+          x={0}
+          y={72}
+          textAnchor="middle"
+          fontSize={SLD_FONT.analog}
+          fontFamily="monospace"
+          fill={powerColor}
+        >
+          {formatPower(realPower)}
         </text>
       </g>
 

--- a/src/components/SingleLineDiagram/elements/chargeGauge.test.ts
+++ b/src/components/SingleLineDiagram/elements/chargeGauge.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for the Megapack charge gauge geometry.
+ *
+ * Run with `bun test src/components/SingleLineDiagram/elements/chargeGauge.test.ts`.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { gaugeFill, gaugeGeometry } from './chargeGauge';
+
+// Matches the Megapack body.
+const GEOMETRY = gaugeGeometry(40, 54);
+
+describe('gaugeGeometry', () => {
+  test('keeps the track clear of the right-hand fan column', () => {
+    // Fans sit at x = w/2 - 6 = 14; the track must not reach them.
+    expect(GEOMETRY.x + GEOMETRY.width).toBeLessThan(14 - 2.2);
+  });
+
+  test('keeps the track inside the body', () => {
+    expect(GEOMETRY.x).toBeGreaterThan(-40 / 2);
+    expect(GEOMETRY.y).toBeGreaterThan(-54 / 2);
+    expect(GEOMETRY.y + GEOMETRY.height).toBeLessThan(54 / 2);
+  });
+});
+
+describe('gaugeFill', () => {
+  test('draws nothing when there is no reading', () => {
+    // An empty track and an empty pack are opposite claims, so a missing
+    // reading draws no gauge at all.
+    expect(gaugeFill(null, GEOMETRY)).toBeNull();
+    expect(gaugeFill(undefined, GEOMETRY)).toBeNull();
+    expect(gaugeFill(NaN, GEOMETRY)).toBeNull();
+  });
+
+  test('draws a zero-height fill for a real zero', () => {
+    // Distinct from the case above: the pack answered, and it is empty.
+    const fill = gaugeFill(0, GEOMETRY);
+    expect(fill).not.toBeNull();
+    expect(fill!.height).toBe(0);
+  });
+
+  test('fills from the bottom', () => {
+    const half = gaugeFill(50, GEOMETRY)!;
+    const full = gaugeFill(100, GEOMETRY)!;
+    const bottom = GEOMETRY.y + GEOMETRY.height;
+
+    // Both end at the same baseline; only the top edge moves.
+    expect(half.y + half.height).toBeCloseTo(full.y + full.height, 5);
+    expect(half.y).toBeGreaterThan(full.y);
+    expect(half.y + half.height).toBeLessThan(bottom);
+  });
+
+  test('is proportional to charge', () => {
+    const quarter = gaugeFill(25, GEOMETRY)!;
+    const half = gaugeFill(50, GEOMETRY)!;
+    expect(half.height).toBeCloseTo(quarter.height * 2, 5);
+  });
+
+  test('never paints outside the track', () => {
+    // Out-of-range values are clamped: painting past the border would read as
+    // a rendering fault rather than the data fault it is.
+    for (const soc of [-10, 0, 50, 100, 150]) {
+      const fill = gaugeFill(soc, GEOMETRY)!;
+      expect(fill.y).toBeGreaterThanOrEqual(GEOMETRY.y);
+      expect(fill.y + fill.height).toBeLessThanOrEqual(GEOMETRY.y + GEOMETRY.height);
+      expect(fill.x).toBeGreaterThanOrEqual(GEOMETRY.x);
+      expect(fill.x + fill.width).toBeLessThanOrEqual(GEOMETRY.x + GEOMETRY.width);
+    }
+  });
+
+  test('leaves a visible border at full charge', () => {
+    // The track outline has to stay readable, or a full pack looks like a
+    // solid block rather than a gauge.
+    const full = gaugeFill(100, GEOMETRY)!;
+    expect(full.height).toBeLessThan(GEOMETRY.height);
+    expect(full.width).toBeLessThan(GEOMETRY.width);
+  });
+});

--- a/src/components/SingleLineDiagram/elements/chargeGauge.ts
+++ b/src/components/SingleLineDiagram/elements/chargeGauge.ts
@@ -1,0 +1,72 @@
+/**
+ * Geometry for the Megapack charge gauge — the client spreadsheet's
+ * "MP gas gauge".
+ *
+ * Split out from the element so the arithmetic is testable without a DOM.
+ * The rules it encodes are the ones worth getting right: a reading of zero
+ * must not look like no reading, and a reading out of range must not paint
+ * outside the track.
+ */
+
+/** Gauge track, in the element's local coordinates. */
+export interface GaugeGeometry {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** The filled portion of the track. */
+export interface GaugeFill {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Border thickness between the track edge and the fill. */
+const INSET = 1;
+
+/**
+ * Track geometry for a pack body `w` x `h`.
+ *
+ * Sits on the left of the body, clear of the right-hand fan column, with
+ * margin so the body outline stays readable when an alarm thickens it.
+ */
+export function gaugeGeometry(w: number, h: number): GaugeGeometry {
+  return { x: -w / 2 + 6, y: -h / 2 + 8, width: 9, height: h - 16 };
+}
+
+/**
+ * The fill rect for `soc`, or `null` when there is nothing to draw.
+ *
+ * Returns `null` for a missing or non-numeric reading — the caller draws no
+ * gauge at all in that case. An empty track is indistinguishable from an
+ * empty pack, and those are opposite claims; no reading shows no gauge,
+ * matching the `--` in the text below the symbol.
+ *
+ * A reading of exactly 0 is a real measurement and does return a rect, of
+ * zero height: the track is drawn, and it reads as empty because it is.
+ *
+ * Values outside 0-100 are clamped rather than rejected. Charge cannot
+ * meaningfully exceed full, and painting past the track would look like a
+ * rendering fault rather than the data fault it is.
+ */
+export function gaugeFill(
+  soc: number | null | undefined,
+  geometry: GaugeGeometry,
+): GaugeFill | null {
+  if (soc == null || Number.isNaN(soc)) return null;
+
+  const pct = Math.max(0, Math.min(100, soc));
+  const usableH = geometry.height - INSET * 2;
+  const height = (pct / 100) * usableH;
+
+  return {
+    x: geometry.x + INSET,
+    // Fills from the bottom, the way a level does.
+    y: geometry.y + geometry.height - INSET - height,
+    width: geometry.width - INSET * 2,
+    height,
+  };
+}

--- a/src/components/SingleLineDiagram/sldAnalogs.test.ts
+++ b/src/components/SingleLineDiagram/sldAnalogs.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for the SLD reducer's analog routing: zone -> component,
+ * spreadsheet field -> display slot, and the null-vs-zero distinction the
+ * gauges depend on.
+ *
+ * Run with `bun test src/components/SingleLineDiagram/sldAnalogs.test.ts`.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { AnalogPointValue, LatestAnalogsResponse, ZoneAnalogs } from '@newtown-energy/types';
+import { sldReducer, createInitialState, defComponent } from './sldState';
+
+function makeState() {
+  return createInitialState(
+    [
+      defComponent('site', 'Site'),
+      defComponent('meter-main', 'Meter', undefined, ['Meter']),
+      defComponent('megapack-1a', 'Mp1a', undefined, ['MP-1A']),
+      defComponent('megapack-2c', 'Mp2c', undefined, ['MP-2C']),
+    ],
+    [],
+  );
+}
+
+function point(name: string, value: number | null, unit: string | null): AnalogPointValue {
+  return { name, offset: 0, address: 0, raw: 0, value, unit };
+}
+
+function zone(partial: Partial<ZoneAnalogs> = {}): ZoneAnalogs {
+  return {
+    state_of_energy: 46.25,
+    ac_voltage: 478.5,
+    max_battery_temperature: 28.2,
+    points: [],
+    ...partial,
+  };
+}
+
+function response(zones: LatestAnalogsResponse['zones']): LatestAnalogsResponse {
+  return { site_id: 1, timestamp: '2026-08-28T14:50:14', zones };
+}
+
+describe('UPDATE_ANALOGS', () => {
+  test('maps spreadsheet field names onto the slots the elements read', () => {
+    const state = sldReducer(makeState(), {
+      type: 'UPDATE_ANALOGS',
+      analogs: response({ Mp1a: zone() }),
+    });
+
+    const analogs = state.components['megapack-1a'].analogs;
+    expect(analogs?.soc).toBe(46.25);
+    expect(analogs?.stackTemp).toBe(28.2);
+    expect(analogs?.outputVoltage).toBe(478.5);
+  });
+
+  test('routes each zone to the component that declares it', () => {
+    const state = sldReducer(makeState(), {
+      type: 'UPDATE_ANALOGS',
+      analogs: response({
+        Mp1a: zone({ state_of_energy: 10 }),
+        Mp2c: zone({ state_of_energy: 90 }),
+      }),
+    });
+
+    expect(state.components['megapack-1a'].analogs?.soc).toBe(10);
+    expect(state.components['megapack-2c'].analogs?.soc).toBe(90);
+    // A component in an unrelated zone must not pick up a neighbour's values.
+    expect(state.components['meter-main'].analogs).toBeUndefined();
+  });
+
+  test('carries a missing reading through as null, never as zero', () => {
+    // A gauge at 0% and a gauge with no reading are opposite claims. This is
+    // the whole reason the slots are nullable.
+    const state = sldReducer(makeState(), {
+      type: 'UPDATE_ANALOGS',
+      analogs: response({ Mp1a: zone({ state_of_energy: null }) }),
+    });
+
+    const analogs = state.components['megapack-1a'].analogs;
+    expect(analogs?.soc).toBeNull();
+    expect(Object.hasOwn(analogs!, 'soc')).toBe(true);
+  });
+
+  test('exposes the rest of the block under its spreadsheet name', () => {
+    const state = sldReducer(makeState(), {
+      type: 'UPDATE_ANALOGS',
+      analogs: response({
+        Mp1a: zone({
+          points: [
+            point('real_power_output', -50, 'kW'),
+            point('ambient_temperature', 25, 'C'),
+            point('AI_spare_1', null, null),
+          ],
+        }),
+      }),
+    });
+
+    const analogs = state.components['megapack-1a'].analogs;
+    expect(analogs?.real_power_output).toBe(-50);
+    expect(analogs?.ambient_temperature).toBe(25);
+    // A spare has no interpretation, so it arrives as null rather than 0.
+    expect(analogs?.AI_spare_1).toBeNull();
+  });
+
+  test('does not let a block point overwrite the named slots', () => {
+    // `state_of_energy` appears both as a top-level field and in `points`.
+    // The named slot must win, or the slot and the gauge could disagree.
+    const state = sldReducer(makeState(), {
+      type: 'UPDATE_ANALOGS',
+      analogs: response({
+        Mp1a: zone({
+          state_of_energy: 46.25,
+          points: [point('state_of_energy', 99, '%')],
+        }),
+      }),
+    });
+
+    expect(state.components['megapack-1a'].analogs?.soc).toBe(46.25);
+    expect(state.components['megapack-1a'].analogs?.state_of_energy).toBeUndefined();
+  });
+
+  test('ignores a zone the diagram does not draw', () => {
+    // The API reports the site, not this layout; an unknown zone is not an
+    // error and must not throw.
+    const state = sldReducer(makeState(), {
+      type: 'UPDATE_ANALOGS',
+      analogs: response({ Transformer1: zone() }),
+    });
+    expect(state.components['megapack-1a'].analogs).toBeUndefined();
+  });
+
+  test('leaves alarm state untouched', () => {
+    // The two polls are independent; an analog update must not reset the
+    // status an alarm poll just set.
+    const base = makeState();
+    base.components['megapack-1a'] = {
+      ...base.components['megapack-1a'],
+      status: 'alarm',
+      activeAlarmCount: 2,
+    };
+    const state = sldReducer(base, {
+      type: 'UPDATE_ANALOGS',
+      analogs: response({ Mp1a: zone() }),
+    });
+
+    expect(state.components['megapack-1a'].status).toBe('alarm');
+    expect(state.components['megapack-1a'].activeAlarmCount).toBe(2);
+  });
+});

--- a/src/components/SingleLineDiagram/sldState.ts
+++ b/src/components/SingleLineDiagram/sldState.ts
@@ -1,4 +1,10 @@
-import type { ActiveAlarmsResponse, AlarmSeverityDto, AlarmZoneDto } from '@newtown-energy/types';
+import type {
+  ActiveAlarmsResponse,
+  AlarmSeverityDto,
+  AlarmZoneDto,
+  LatestAnalogsResponse,
+  ZoneAnalogs,
+} from '@newtown-energy/types';
 import { getSeverityOrder } from '../../utils/alarmHelpers';
 import { ESTOP_ALARM_NUM } from '../../utils/estopApi';
 import { resolveAlarmSeverity } from '../../config/siteConfig';
@@ -55,6 +61,47 @@ function resolveAlarmTargets(
   return zoneIds(components, zone);
 }
 
+/**
+ * API field name -> the display slot the SLD elements read.
+ *
+ * The wire format uses the client spreadsheet's names (`state_of_energy`) and
+ * the elements use display names (`soc`); this table is the seam between them.
+ * Keeping them distinct is deliberate — the backend stays checkable against the
+ * client spec, and renaming a gauge here does not mean renaming a wire field.
+ */
+const ANALOG_FIELD_TO_SLOT = {
+  state_of_energy: 'soc',
+  max_battery_temperature: 'stackTemp',
+  ac_voltage: 'outputVoltage',
+} as const;
+
+/**
+ * Turn one zone's payload into the element's analog slots.
+ *
+ * A field the API reported as `null` is carried through as `null` rather than
+ * dropped: the slot exists but has no reading, which the elements render as
+ * `--`. Omitting the key entirely would look identical, but `null` says it
+ * explicitly and keeps the slot list stable between polls.
+ */
+function slotsForZone(zone: ZoneAnalogs): Record<string, number | null> {
+  // Named through the table above rather than by repeating the slot names,
+  // so renaming a slot cannot leave the mapping and the assignment disagreeing.
+  // These come from the top-level fields, which are present even on readings
+  // stored before the raw register block was kept.
+  const slots: Record<string, number | null> = {
+    [ANALOG_FIELD_TO_SLOT.state_of_energy]: zone.state_of_energy,
+    [ANALOG_FIELD_TO_SLOT.max_battery_temperature]: zone.max_battery_temperature,
+    [ANALOG_FIELD_TO_SLOT.ac_voltage]: zone.ac_voltage,
+  };
+  // Everything else in the block, under its spreadsheet name, so an element
+  // can start showing a measurement without another round through the API.
+  for (const point of zone.points) {
+    if (point.name in ANALOG_FIELD_TO_SLOT) continue;
+    slots[point.name] = point.value;
+  }
+  return slots;
+}
+
 // --- Actions ---
 
 export type SldAction =
@@ -62,6 +109,7 @@ export type SldAction =
   | { type: 'TOGGLE_BREAKER'; componentId: string }
   | { type: 'SET_SWITCH_POSITION'; componentId: string; position: 'open' | 'closed' }
   | { type: 'SET_POWER_FLOW'; wireId: string; direction: PowerFlowDirection }
+  | { type: 'UPDATE_ANALOGS'; analogs: LatestAnalogsResponse }
   | { type: 'MARK_STALE' };
 
 // --- Helpers ---
@@ -221,6 +269,23 @@ export function sldReducer(
           },
         },
       };
+    }
+
+    case 'UPDATE_ANALOGS': {
+      const updated: Record<string, SldComponentState> = { ...state.components };
+      for (const [zone, values] of Object.entries(action.analogs.zones)) {
+        if (!values) continue;
+        const slots = slotsForZone(values);
+        // Routed by the component's own zone rather than a layout's
+        // zone-to-id table: that keeps the reducer independent of any
+        // particular diagram, and matches how alarms already find their
+        // targets. A zone the diagram does not draw yields no ids and is
+        // skipped — the API reports the site, not this layout.
+        for (const id of zoneIds(state.components, zone as AlarmZoneDto)) {
+          updated[id] = { ...updated[id], analogs: slots };
+        }
+      }
+      return { ...state, components: updated };
     }
 
     case 'MARK_STALE':

--- a/src/components/SingleLineDiagram/useSldAnalogs.ts
+++ b/src/components/SingleLineDiagram/useSldAnalogs.ts
@@ -1,0 +1,58 @@
+import { useEffect } from 'react';
+import { fetchLatestAnalogs } from '../../utils/analogApi';
+import { errorLog } from '../../utils/debug';
+import type { SldAction } from './sldState';
+
+const POLL_INTERVAL_MS = 10_000;
+
+/**
+ * Polls the latest per-zone analog values and dispatches UPDATE_ANALOGS to
+ * keep the diagram's gauges in sync. Runs on the same 10s cadence as
+ * `useSldAlarms`, because the two poll the same site and there is no reason
+ * for the gauges and the alarms to disagree about how current they are.
+ *
+ * Failure handling is deliberately *not* the same as `useSldAlarms`, which
+ * dispatches MARK_STALE. A failed poll here leaves the last values on screen:
+ * the diagram already has one staleness signal, driven by the alarm poll, and
+ * that is what tells an operator the picture is old. Blanking the gauges would
+ * instead claim the packs reported nothing, which is a different and untrue
+ * statement.
+ *
+ * Cancellation is per effect run rather than a shared mounted flag. A shared
+ * flag cannot express "this response is for the site we just left" — cleanup
+ * clears it and the next run immediately sets it again, so a request in flight
+ * for the previous site still dispatches and paints its values onto the new
+ * one. A flag scoped to the run that started the request cannot be revived by
+ * a later run, so a late response is dropped rather than shown against the
+ * wrong site.
+ */
+export function useSldAnalogs(
+  dispatch: React.Dispatch<SldAction>,
+  siteId: number | null,
+  pollIntervalMs = POLL_INTERVAL_MS,
+): void {
+  useEffect(() => {
+    if (siteId == null) return;
+
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const analogs = await fetchLatestAnalogs(siteId);
+        if (!cancelled) {
+          dispatch({ type: 'UPDATE_ANALOGS', analogs });
+        }
+      } catch (err) {
+        errorLog('SLD analog poll failed:', err);
+      }
+    };
+
+    load();
+    const interval = setInterval(load, pollIntervalMs);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [dispatch, siteId, pollIntervalMs]);
+}

--- a/src/utils/analogApi.ts
+++ b/src/utils/analogApi.ts
@@ -1,0 +1,15 @@
+import type { LatestAnalogsResponse } from '@newtown-energy/types';
+
+import { apiRequestWithMapping } from './api';
+
+/**
+ * Fetch the most recent per-zone analog measurements for a site.
+ *
+ * Not a time series — this answers "what is true now". `fetchSocHistory` is
+ * the one to reach for when you want a window.
+ */
+export async function fetchLatestAnalogs(siteId: number): Promise<LatestAnalogsResponse> {
+  return await apiRequestWithMapping<LatestAnalogsResponse>(
+    `/api/1/Sites/${siteId}/LatestAnalogs`,
+  );
+}


### PR DESCRIPTION
Closes #108.

Depends on Newtown-Energy/neems-core#104 — **now merged**, which serves
`GET /api/1/Sites/<id>/LatestAnalogs` and publishes `@newtown-energy/types`
**0.6.0**, the version this branch depends on.

## What

`SldComponentState.analogs` was read by `Megapack.tsx` and `Meter.tsx` and
written by nothing, so every pack has rendered `Charge -- %` since the slots
were added.

| commit | |
|---|---|
| `7b6a14e` | Depend on the published types 0.6.0 |
| `d3561ac` | Make the TypeScript lint actually check something |
| `bc1de4c` | Poll live analog values into the diagram |
| `5c44449` | Give charge its own gauge instead of tinting the pack |
| `307f6a8` | Show each pack's real power on the diagram |
| `543826b` | Draw one junction dot per bus coordinate |

Ordered so the branch is bisectable: the dependency and the tooling fix land
before the code that needs them.

### Polling the values

A 10s poll of `LatestAnalogs` and an `UPDATE_ANALOGS` action.

- **Routed by the component's own zone**, not a layout's zone-to-id table. Keeps
  the reducer independent of any particular diagram (it is the rule alarms
  already use), so a zone this layout does not draw is skipped rather than being
  an error. The API reports the site; it does not know what we chose to render.
- **`ANALOG_FIELD_TO_SLOT` is the seam** between the wire's spreadsheet names
  (`state_of_energy`) and the elements' display names (`soc`), and is the single
  source of those slot names.
- **`null` is carried through, never coerced to 0.** A gauge at 0% and a gauge
  with no reading are opposite claims.
- **Cancellation is per effect run**, not a shared mounted flag — a flag cleared
  on cleanup and re-set by the next run cannot express "this response is for the
  site we just left".
- **A failed poll leaves the last values up.** The diagram already has a
  staleness signal from the alarm poll; blanking here would instead claim the
  packs reported nothing.

### The gauge

The old bar filled the whole body with 30%-opacity green — the same rect
`useStatusColors`, `AlarmGlow` and the fire-keyword wash already use, so a
half-charged pack and a faintly alarmed one looked alike. Replaced with an inset
bordered track on the left, clear of the fan column: the spreadsheet's "MP gas
gauge". No gauge at all when there is no reading; a real zero *does* draw the
track with a zero-height fill.

Geometry lives in `chargeGauge.ts` as pure functions — clamping inside the
track, filling from the bottom, keeping the border visible at 100% — none of
which was reachable by a test while inline in a component.

### Real power

`chg 950 kW` / `dis 950 kW` rather than a signed number: the sign *is* the
reading, and a bare `-950 kW` makes the reader remember which way the convention
runs. Zero reads `idle`.

### Two unrelated fixes, found while doing this

**`d3561ac`** — `lint:tsc` ran `tsc --noEmit` against a solution-style
`tsconfig.json` (`"files": []` plus references). Outside build mode tsc does not
follow references, so it checked **zero files** and exited 0 unconditionally, and
CI runs it as its typecheck job. Demonstrated, not assumed: appending
`const x: number = "nope";` left it passing. This is why a broken commit reached
this branch. Now runs `tsc -b`.

**`543826b`** — both 480V buses pass a duplicate x (switch drop and middle feeder
share 390 on bus 1, 870 on bus 2), producing two React children with the same
key. Nothing looked wrong because the dots painted identical pixels, but React
resolves duplicate keys by dropping one, which on a connectivity diagram could
leave a junction unmarked.

Happy to split either into its own PR if the mixed concerns are unwelcome.

## Verification

- Every commit independently passes `tsc -b`, `eslint --max-warnings=0` and the
  suite (53 → 53 → 60 → 68 → 68 → 68), run against the **published**
  `@newtown-energy/types@0.6.0`, not the devenv link.
- Rendered and driven against the live stack: six packs with distinct charge,
  gauges tracking, `dis 237…262 kW` under load with charge draining and
  temperatures rising. No console errors.

## Not covered by a test

The site-switch cancellation fix. Testing it needs the hook actually rendered,
and this repo has no component/hook test setup; a test that models the contract
without importing the hook would pass with the fix reverted, so there isn't one.

## Left alone

`Meter.tsx`'s `kW`/`kVar`/`voltage`/`amps` slots. The `Analogs` sheet defines no
meter points, so the only way to fill them is summing pack output — which is not
what the revenue meter reads (transformer losses, house load) and would present
an estimate as a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: 4f164426-00a4-448e-9635-c5fe3e3e7096
