### PR TITLE
Render alarms from the two independent alarm state axes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "recharts": "^3.8.1",
       },
       "devDependencies": {
-        "@newtown-energy/types": "0.6.0",
+        "@newtown-energy/types": "0.7.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.0.10",
         "@types/react": "^19.1.8",
@@ -331,7 +331,7 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
-    "@newtown-energy/types": ["@newtown-energy/types@0.6.0", "https://npm.pkg.github.com/download/@newtown-energy/types/0.6.0/0eda1d450bee1ecd32dfd30b8ea79b8b3d517fda", {}, "sha512-wVPo77NdsTE9mNpBz02M2GQuuIRyI2sZSJoAUYhe10SLqww78FqqO/CevzxW0kbjZb62IfDiDD0PW2foAf8pWA=="],
+    "@newtown-energy/types": ["@newtown-energy/types@0.7.0", "https://npm.pkg.github.com/download/@newtown-energy/types/0.7.0/4ef1de0810ec563d022777f67b2a4c2eeab9d530", {}, "sha512-1yDkjjFECFRUwYQ8zmRdJwkZjxV2WGEPKVhHiA5q99GNaH6Gy8HEWgPWq1Fk3lxwPIIOv4u3Gwyap/J2ay/UcQ=="],
 
     "@parcel/watcher": ["@parcel/watcher@2.5.6", "", { "dependencies": { "detect-libc": "^2.0.3", "is-glob": "^4.0.3", "node-addon-api": "^7.0.0", "picomatch": "^4.0.3" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.6", "@parcel/watcher-darwin-arm64": "2.5.6", "@parcel/watcher-darwin-x64": "2.5.6", "@parcel/watcher-freebsd-x64": "2.5.6", "@parcel/watcher-linux-arm-glibc": "2.5.6", "@parcel/watcher-linux-arm-musl": "2.5.6", "@parcel/watcher-linux-arm64-glibc": "2.5.6", "@parcel/watcher-linux-arm64-musl": "2.5.6", "@parcel/watcher-linux-x64-glibc": "2.5.6", "@parcel/watcher-linux-x64-musl": "2.5.6", "@parcel/watcher-win32-arm64": "2.5.6", "@parcel/watcher-win32-ia32": "2.5.6", "@parcel/watcher-win32-x64": "2.5.6" } }, "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "recharts": "^3.8.1"
   },
   "devDependencies": {
-    "@newtown-energy/types": "0.6.0",
+    "@newtown-energy/types": "0.7.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.0.10",
     "@types/react": "^19.1.8",

--- a/src/components/SingleLineDiagram/elements/AlarmGlow.tsx
+++ b/src/components/SingleLineDiagram/elements/AlarmGlow.tsx
@@ -23,11 +23,11 @@ interface AlarmGlowProps {
  * local coordinate space (assumes the parent has already translated to the
  * entity's center) so callers only need to provide the entity's half-size.
  *
- * The glow pulses only while at least one currently-active alarm is still
- * unacknowledged (`status === 'Active'`). Once every active alarm on the
- * component has been acknowledged (`AcknowledgedActive`), the glow renders
- * without its pulse animation so the operator isn't visually pestered — the
- * static color remains as a findable cue that the alarm is still present.
+ * The glow pulses only while at least one currently-firing alarm is still
+ * unacknowledged. Once every firing alarm on the component has been
+ * acknowledged, the glow renders without its pulse animation so the operator
+ * isn't visually pestered — the static color remains as a findable cue that
+ * the condition is still present.
  */
 const AlarmGlow: React.FC<AlarmGlowProps> = ({
   state,
@@ -45,10 +45,11 @@ const AlarmGlow: React.FC<AlarmGlowProps> = ({
   if (!shouldPulse) return null;
 
   const color = severityColor(state.highestSeverity, theme);
-  // Pulse only while something is still firing AND unacknowledged. A
-  // ReturnedUnacknowledged alarm is no longer firing, so it doesn't drive the
-  // pulsing glow (the AlarmIndicator badge carries its distinct cue instead).
-  const animate = state.activeAlarms.some((a) => a.status === 'Active');
+  // Pulse only while something is still firing AND unacknowledged. An alarm
+  // that has returned to normal without being acknowledged is no longer
+  // firing, so it doesn't drive the pulsing glow (the AlarmIndicator badge
+  // carries its distinct cue instead).
+  const animate = state.activeAlarms.some((a) => a.dataActive && !a.acknowledged);
 
   // No stroke on the glow — the parent entity already renders a severity-tinted
   // stroke via useStatusColors, so an outlined halo here would read as a

--- a/src/components/SingleLineDiagram/elements/AlarmIndicator.tsx
+++ b/src/components/SingleLineDiagram/elements/AlarmIndicator.tsx
@@ -15,11 +15,6 @@ interface AlarmIndicatorProps {
   offsetY: number;
 }
 
-/** True for alarms still awaiting acknowledgement (firing now or latched). */
-function needsAck(alarm: ActiveAlarmSummary): boolean {
-  return alarm.status === 'Active' || alarm.status === 'ReturnedUnacknowledged';
-}
-
 /** Format an acknowledgement timestamp for compact display. */
 function formatAckTime(iso: string | null): string | null {
   if (!iso) return null;
@@ -57,10 +52,10 @@ function trianglePoints(r: number): string {
  * All shapes are sized to a similar visual area so the alarm count stays
  * legible inside.
  *
- * When `returned` is set (every alarm on the component is
- * ReturnedUnacknowledged — no longer firing but latched awaiting ack) the
- * shape renders hollow with a dashed outline so the operator can tell it apart
- * at a glance from a currently-active alarm, which renders solid.
+ * When `returned` is set (no alarm on the component is firing any more, but
+ * one is still awaiting acknowledgement) the shape renders hollow with a
+ * dashed outline so the operator can tell it apart at a glance from a
+ * currently-active alarm, which renders solid.
  */
 const SeverityShape: React.FC<{
   severity: AlarmSeverityDto;
@@ -119,15 +114,14 @@ const AlarmIndicator: React.FC<AlarmIndicatorProps> = ({ state, offsetX, offsetY
   const shouldPulse =
     state.highestSeverity === 'Emergency' || state.highestSeverity === 'Critical';
   // Pulse only while at least one alarm is firing now AND unacknowledged.
-  const anyActiveUnacked = state.activeAlarms.some((a) => a.status === 'Active');
+  const anyActiveUnacked = state.activeAlarms.some((a) => a.dataActive && !a.acknowledged);
   const animate = shouldPulse && anyActiveUnacked;
   // Distinct "returned, needs ack" look: every alarm on the component is
   // latched-but-not-firing. A single still-firing alarm reverts to the solid
   // active look so the more urgent state always wins.
   const allReturned =
-    state.activeAlarms.length > 0 &&
-    state.activeAlarms.every((a) => a.status === 'ReturnedUnacknowledged');
-  const unackedCount = state.activeAlarms.filter(needsAck).length;
+    state.activeAlarms.length > 0 && state.activeAlarms.every((a) => !a.dataActive);
+  const unackedCount = state.activeAlarms.filter((a) => !a.acknowledged).length;
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -152,7 +146,7 @@ const AlarmIndicator: React.FC<AlarmIndicatorProps> = ({ state, offsetX, offsetY
 
   const handleAcknowledgeAll = () => {
     void runAck(
-      state.activeAlarms.filter(needsAck).map((a) => a.alarm_num),
+      state.activeAlarms.filter((a) => !a.acknowledged).map((a) => a.alarm_num),
       'all',
     );
   };
@@ -225,8 +219,11 @@ const AlarmIndicator: React.FC<AlarmIndicatorProps> = ({ state, offsetX, offsetY
             </Typography>
             <Stack spacing={0.75} sx={{ mt: 1 }}>
               {state.activeAlarms.map((alarm) => {
-                const acked = alarm.status === 'AcknowledgedActive';
-                const returned = alarm.status === 'ReturnedUnacknowledged';
+                // The two axes drive the two visual cues independently:
+                // `firing` decides solid vs hollow, `returned` adds the dashed
+                // "no longer firing but still owed an ack" marker.
+                const firing = alarm.dataActive && !alarm.acknowledged;
+                const returned = !alarm.dataActive && !alarm.acknowledged;
                 const ackTime = formatAckTime(alarm.acknowledgedAt);
                 return (
                   <Box key={alarm.alarm_num}>
@@ -235,17 +232,18 @@ const AlarmIndicator: React.FC<AlarmIndicatorProps> = ({ state, offsetX, offsetY
                         label={formatAlarmName(alarm.name)}
                         color={getSeverityColor(alarm.severity)}
                         size="small"
-                        // Hollow chip for acked (paused) and for returned. A
-                        // dashed border additionally marks the returned blip so
-                        // it reads apart from a currently-active alarm.
-                        variant={alarm.status === 'Active' ? 'filled' : 'outlined'}
+                        // Hollow chip once an alarm is either acknowledged or
+                        // no longer firing. A dashed border additionally marks
+                        // the returned blip so it reads apart from a
+                        // currently-active alarm.
+                        variant={firing ? 'filled' : 'outlined'}
                         sx={{
                           flex: 1,
-                          opacity: alarm.status === 'Active' ? 1 : 0.7,
+                          opacity: firing ? 1 : 0.7,
                           ...(returned ? { borderStyle: 'dashed' } : {}),
                         }}
                       />
-                      {needsAck(alarm) && (
+                      {!alarm.acknowledged && (
                         <Button
                           size="small"
                           variant="contained"
@@ -265,7 +263,7 @@ const AlarmIndicator: React.FC<AlarmIndicatorProps> = ({ state, offsetX, offsetY
                         Returned to normal — still needs acknowledgement
                       </Typography>
                     )}
-                    {acked && (
+                    {alarm.acknowledged && (
                       <Typography
                         variant="caption"
                         color="text.secondary"
@@ -281,7 +279,7 @@ const AlarmIndicator: React.FC<AlarmIndicatorProps> = ({ state, offsetX, offsetY
                         variant="caption"
                         color="text.secondary"
                         component="div"
-                        sx={{ pl: 0.5, mt: 0.25, opacity: alarm.status === 'Active' ? 1 : 0.7 }}
+                        sx={{ pl: 0.5, mt: 0.25, opacity: firing ? 1 : 0.7 }}
                       >
                         {alarm.message}
                       </Typography>

--- a/src/components/SingleLineDiagram/elements/AlarmIndicator.tsx
+++ b/src/components/SingleLineDiagram/elements/AlarmIndicator.tsx
@@ -116,11 +116,14 @@ const AlarmIndicator: React.FC<AlarmIndicatorProps> = ({ state, offsetX, offsetY
   // Pulse only while at least one alarm is firing now AND unacknowledged.
   const anyActiveUnacked = state.activeAlarms.some((a) => a.dataActive && !a.acknowledged);
   const animate = shouldPulse && anyActiveUnacked;
-  // Distinct "returned, needs ack" look: every alarm on the component is
-  // latched-but-not-firing. A single still-firing alarm reverts to the solid
-  // active look so the more urgent state always wins.
+  // Distinct "returned, needs ack" look: every alarm on the component has
+  // stopped firing and is still owed an acknowledgement. A single still-firing
+  // alarm reverts to the solid active look so the more urgent state always
+  // wins. Both axes are named rather than relying on the backend omitting the
+  // cleared-and-acknowledged quadrant from the list.
   const allReturned =
-    state.activeAlarms.length > 0 && state.activeAlarms.every((a) => !a.dataActive);
+    state.activeAlarms.length > 0 &&
+    state.activeAlarms.every((a) => !a.dataActive && !a.acknowledged);
   const unackedCount = state.activeAlarms.filter((a) => !a.acknowledged).length;
 
   const handleClick = (e: React.MouseEvent) => {

--- a/src/components/SingleLineDiagram/sldState.test.ts
+++ b/src/components/SingleLineDiagram/sldState.test.ts
@@ -33,8 +33,8 @@ function alarm(partial: Partial<ActiveAlarmDto> & Pick<ActiveAlarmDto, 'alarm_nu
     severity: 'Warning',
     message: null,
     sld_targets: [],
-    status: 'Active',
     data_active: true,
+    acknowledged: false,
     acknowledged_at: null,
     acknowledged_by_user_id: null,
     acknowledged_by_email: null,
@@ -90,15 +90,17 @@ describe('sldReducer alarm routing', () => {
         alarm_num: 101,
         zone: 'BreakerRelay',
         sld_targets: ['52-MAIN-1'],
-        status: 'AcknowledgedActive',
         data_active: true,
+        acknowledged: true,
         acknowledged_by_email: 'operator@example.com',
         acknowledged_at: '2026-06-19T01:23:45Z',
       }),
     ]);
     const summary = state.components['switch-89l-1'].activeAlarms[0];
-    expect(summary.status).toBe('AcknowledgedActive');
+    // Acknowledged and still firing: the two axes travel independently, so an
+    // acknowledged alarm must not read as though the condition went away.
     expect(summary.dataActive).toBe(true);
+    expect(summary.acknowledged).toBe(true);
     expect(summary.acknowledgedByEmail).toBe('operator@example.com');
     expect(summary.acknowledgedAt).toBe('2026-06-19T01:23:45Z');
   });
@@ -109,13 +111,15 @@ describe('sldReducer alarm routing', () => {
         alarm_num: 101,
         zone: 'BreakerRelay',
         sld_targets: ['52-MAIN-1'],
-        status: 'ReturnedUnacknowledged',
         data_active: false,
+        acknowledged: false,
       }),
     ]);
     const summary = state.components['switch-89l-1'].activeAlarms[0];
-    expect(summary.status).toBe('ReturnedUnacknowledged');
+    // No longer firing, still owed an acknowledgement — the case the latch
+    // exists for, so it must survive the mapping intact.
     expect(summary.dataActive).toBe(false);
+    expect(summary.acknowledged).toBe(false);
   });
 
   test('falls back to zone matching when no token maps to a component', () => {

--- a/src/components/SingleLineDiagram/sldState.ts
+++ b/src/components/SingleLineDiagram/sldState.ts
@@ -148,8 +148,8 @@ function applyAlarms(
       name: alarm.name,
       severity,
       message: alarm.message ?? null,
-      status: alarm.status,
       dataActive: alarm.data_active,
+      acknowledged: alarm.acknowledged,
       acknowledgedByEmail: alarm.acknowledged_by_email ?? null,
       acknowledgedAt: alarm.acknowledged_at ?? null,
     };

--- a/src/components/SingleLineDiagram/types.ts
+++ b/src/components/SingleLineDiagram/types.ts
@@ -1,4 +1,4 @@
-import type { AlarmSeverityDto, AlarmStatusDto, AlarmZoneDto } from '@newtown-energy/types';
+import type { AlarmSeverityDto, AlarmZoneDto } from '@newtown-energy/types';
 
 /** Summary of a single active alarm on a component */
 export interface ActiveAlarmSummary {
@@ -10,16 +10,16 @@ export interface ActiveAlarmSummary {
   /** Operator-facing message from the alarm spreadsheet ("Mouseover").
    *  `null` when the spreadsheet had none — callers fall back to the name. */
   message: string | null;
-  /** Server-authoritative acknowledgement status. `Active` = unacked and
-   *  firing now; `AcknowledgedActive` = acked but still firing;
-   *  `ReturnedUnacknowledged` = no longer firing but latched awaiting ack. */
-  status: AlarmStatusDto;
-  /** Raw current data state, independent of acknowledgement. `false` for a
+  /** Whether the condition is physically present right now. `false` for a
    *  returned-to-normal alarm still latched awaiting acknowledgement. */
   dataActive: boolean;
-  /** Email of the most recent acknowledger, for display; `null` if unacked. */
+  /** Whether an operator has acknowledged the alarm since it last went active.
+   *  Orthogonal to [dataActive]: an acknowledged alarm may still be firing, and
+   *  a cleared one may still be waiting to be acknowledged. */
+  acknowledged: boolean;
+  /** Email of the acknowledger, for display; `null` if unacknowledged. */
   acknowledgedByEmail: string | null;
-  /** ISO 8601 timestamp of the most recent acknowledgement; `null` if unacked. */
+  /** ISO 8601 timestamp of the acknowledgement in force; `null` if unacked. */
   acknowledgedAt: string | null;
 }
 

--- a/src/pages/AlarmsPage.tsx
+++ b/src/pages/AlarmsPage.tsx
@@ -40,7 +40,6 @@ import type {
   AlarmDefinitionDto,
   AlarmHistoryEntry,
   AlarmSeverityDto,
-  AlarmStatusDto,
   AlarmZoneDto,
 } from '@newtown-energy/types';
 import {
@@ -84,15 +83,18 @@ interface AlarmRow {
   /** The alarm is outstanding: the backend still reports it, because it is
    *  firing now *or* it returned to normal without being acknowledged.
    *
-   *  Deliberately not called `active` — a latched `ReturnedUnacknowledged`
-   *  alarm has `data_active: false` and is not firing, but still demands the
-   *  operator's attention, so it sorts, filters and colours like one. Read
-   *  `status` when you need to know whether the condition is present. */
+   *  Deliberately not called `active` — an alarm that returned to normal
+   *  unacknowledged is not firing, but still demands the operator's attention,
+   *  so it sorts, filters and colours like one. Read [dataActive] when you need
+   *  to know whether the condition is present. */
   visible: boolean;
-  /** Server-authoritative acknowledgement status when the alarm is currently
-   *  visible (active or latched); `null` for an inactive definition row. */
-  status: AlarmStatusDto | null;
-  /** Email of the most recent acknowledger, for display; `null` if unacked. */
+  /** Whether the condition is physically present right now. Meaningful only
+   *  when [visible]; `false` for an inactive definition row. */
+  dataActive: boolean;
+  /** Whether an operator has acknowledged the alarm since it last went active.
+   *  Orthogonal to [dataActive], and meaningful only when [visible]. */
+  acknowledged: boolean;
+  /** Email of the acknowledger, for display; `null` if unacknowledged. */
   acknowledgedByEmail: string | null;
   /** Number of activations in the last [HISTORY_WINDOW_DAYS] days. */
   activations30d: number;
@@ -104,27 +106,6 @@ type HistoryState =
   | { kind: 'error'; message: string };
 
 const HISTORY_WINDOW_DAYS = 30;
-
-/** The alarm's data state — whether the condition is physically present.
- *
- *  Acknowledgement is a separate, orthogonal axis: acking an alarm records that
- *  someone has seen it, and does nothing to the condition itself. Labelling an
- *  acknowledged-but-still-firing alarm "Acknowledged" implied it had stopped,
- *  so the two are reported independently — this label, plus [isAcknowledged]. */
-function dataStateLabel(status: AlarmStatusDto): string {
-  switch (status) {
-    case 'Active':
-    case 'AcknowledgedActive':
-      return 'Active';
-    case 'ReturnedUnacknowledged':
-      return 'Cleared';
-  }
-}
-
-/** Whether the alarm has been acknowledged since it last went active. */
-function isAcknowledged(status: AlarmStatusDto): boolean {
-  return status === 'AcknowledgedActive';
-}
 
 type SortKey = 'activations' | 'name' | 'severity' | 'zone';
 type SortDir = 'asc' | 'desc';
@@ -262,7 +243,8 @@ const AlarmsPage: React.FC = () => {
         message: def.message ?? null,
         severity: resolveAlarmSeverity(def.alarm_num, def.severity),
         visible: activeAlarm != null,
-        status: activeAlarm?.status ?? null,
+        dataActive: activeAlarm?.data_active ?? false,
+        acknowledged: activeAlarm?.acknowledged ?? false,
         acknowledgedByEmail: activeAlarm?.acknowledged_by_email ?? null,
         activations30d: activationCounts[def.alarm_num] ?? 0,
       };
@@ -546,6 +528,12 @@ const AlarmsPage: React.FC = () => {
             {rows.map((alarm) => {
               const isExpanded = expanded.has(alarm.alarm_num);
               const rowHistory = history[alarm.alarm_num];
+              // The two axes drive the two cues independently. Acknowledgement
+              // is not the same as clearing, so the chip reports the condition
+              // and the badge beside it reports whether anyone has seen it.
+              const firing = alarm.visible && alarm.dataActive && !alarm.acknowledged;
+              const returned = alarm.visible && !alarm.dataActive;
+              const needsAck = alarm.visible && !alarm.acknowledged;
               return (
                 <React.Fragment key={alarm.alarm_num}>
                   <TableRow
@@ -566,25 +554,20 @@ const AlarmsPage: React.FC = () => {
                     <TableCell>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                         <Chip
-                          label={alarm.status ? dataStateLabel(alarm.status) : 'OK'}
+                          label={alarm.visible ? (alarm.dataActive ? 'Active' : 'Cleared') : 'OK'}
                           color={alarm.visible ? getSeverityColor(alarm.severity) : 'default'}
                           // Solid only while currently firing AND unacked. Acked
                           // and returned-but-unacked alarms render hollow; the
                           // returned blip additionally gets a dashed border so it
                           // reads apart from a currently-active alarm.
-                          variant={alarm.status === 'Active' ? 'filled' : 'outlined'}
+                          variant={firing ? 'filled' : 'outlined'}
                           size="small"
-                          sx={
-                            alarm.status === 'ReturnedUnacknowledged'
-                              ? { borderStyle: 'dashed' }
-                              : undefined
-                          }
+                          sx={returned ? { borderStyle: 'dashed' } : undefined}
                         />
-                        {alarm.status && isAcknowledged(alarm.status) && (
+                        {alarm.visible && alarm.acknowledged && (
                           <Chip label="Acknowledged" size="small" variant="outlined" />
                         )}
-                        {(alarm.status === 'Active' ||
-                          alarm.status === 'ReturnedUnacknowledged') && (
+                        {needsAck && (
                           <Button
                             size="small"
                             variant="contained"
@@ -595,7 +578,7 @@ const AlarmsPage: React.FC = () => {
                           </Button>
                         )}
                       </Box>
-                      {alarm.status === 'AcknowledgedActive' && alarm.acknowledgedByEmail && (
+                      {alarm.visible && alarm.acknowledged && alarm.acknowledgedByEmail && (
                         <Typography variant="caption" color="text.secondary" component="div">
                           by {alarm.acknowledgedByEmail}
                         </Typography>

--- a/src/pages/AlarmsPage.tsx
+++ b/src/pages/AlarmsPage.tsx
@@ -532,7 +532,7 @@ const AlarmsPage: React.FC = () => {
               // is not the same as clearing, so the chip reports the condition
               // and the badge beside it reports whether anyone has seen it.
               const firing = alarm.visible && alarm.dataActive && !alarm.acknowledged;
-              const returned = alarm.visible && !alarm.dataActive;
+              const returned = alarm.visible && !alarm.dataActive && !alarm.acknowledged;
               const needsAck = alarm.visible && !alarm.acknowledged;
               return (
                 <React.Fragment key={alarm.alarm_num}>

--- a/src/pages/FDNYPage.tsx
+++ b/src/pages/FDNYPage.tsx
@@ -119,10 +119,10 @@ const FDNYPage: React.FC = () => {
       ]);
       setEntries(history.entries);
       // Only alarms whose condition is physically present. `/Alarms/Active`
-      // also returns latched ones (ReturnedUnacknowledged, `data_active:
-      // false`) that are visible but no longer firing — counting those as
-      // "active now" made a cleared alarm's latest transition disagree with
-      // present state, costing it the CURRENT tag.
+      // also returns latched ones (`data_active: false`, still unacknowledged)
+      // that are visible but no longer firing — counting those as "active now"
+      // made a cleared alarm's latest transition disagree with present state,
+      // costing it the CURRENT tag.
       setActiveAlarmNums(
         new Set(active.alarms.filter((a) => a.data_active).map((a) => a.alarm_num)),
       );

--- a/src/utils/alarmApi.ts
+++ b/src/utils/alarmApi.ts
@@ -57,8 +57,9 @@ export async function fetchDemoAlarmState(): Promise<DemoAlarmStateResponse> {
  *
  * This writes a real data-state transition, so it behaves like the RTAC feed
  * would: deactivating an alarm does NOT hide it. An alarm that has not been
- * acknowledged since it fired stays visible as `ReturnedUnacknowledged` until
- * an operator acknowledges it, which is the point of the latch.
+ * acknowledged since it fired stays visible — no longer firing, still owed an
+ * acknowledgement — until an operator acknowledges it, which is the point of
+ * the latch.
  */
 export async function setDemoAlarmState(
   alarmNum: number,


### PR DESCRIPTION
Fixes #110. Frontend half of Newtown-Energy/neems-core#107.

The backend now reports the two axes of alarm state separately —
`data_active` and a new `acknowledged` — instead of the fused three-value
`AlarmStatusDto`, which is removed.

## What changed

Every consumer already unpacked the enum back into the two axes at the point of
use, so this mostly deletes the undoing:

- `needsAck` in `AlarmIndicator` was `status === 'Active' || status ===
  'ReturnedUnacknowledged'` — i.e. exactly `!acknowledged`. Gone.
- `dataStateLabel` in `AlarmsPage` mapped two enum members to `Active` and one
  to `Cleared` — i.e. exactly `data_active`. Gone.
- `isAcknowledged` was `status === 'AcknowledgedActive'`. Gone.

Sites that genuinely need both axes now say so directly: `AlarmGlow` pulses on
`dataActive && !acknowledged`, and `AlarmIndicator`/`AlarmsPage` derive `firing`
/ `returned` / `needsAck` once per render instead of testing enum members
inline.

**Nothing about the rendering changes.** The three looks an operator can tell
apart are all still there — firing-and-unacknowledged (solid, pulsing at
Critical/Emergency), firing-and-acknowledged (hollow, acknowledger named), and
returned-but-unacknowledged (hollow, dashed border). They are just derived from
the axis each one actually depends on.

The behavioural change rides along from the backend: acknowledging a firing
alarm now settles that activation for good, so it ends when the condition clears
instead of asking the operator a second time. Only a re-activation makes an
alarm unacknowledged again.

## Verification

Typecheck, eslint (`--max-warnings=0`) and the 68 unit tests all pass against
locally-generated 0.7.0 types. `sldState.test.ts` fixtures moved to the boolean
pairs, and the two acknowledgement cases now assert each axis independently —
that an acknowledged alarm still reports `dataActive: true` (it must not read as
though the condition went away), and that a cleared-unacked blip survives the
mapping intact.

## Types

Pinned to `@newtown-energy/types` **0.7.0**, published from
Newtown-Energy/neems-core#107 on merge. `package.json` and `bun.lock` are both
updated — the lockfile carries a per-version integrity hash, so the two have to
move together or the install breaks.

Verified against the published package (not a local build): typecheck, eslint,
68 unit tests, and `bun run build` all pass.

## Review

Both inline comments taken in 2aa3438: `returned` / `allReturned` drove the
dashed "no longer firing, still needs acknowledgement" styling while testing
only the data axis. They held because the backend omits the cleared-and-
acknowledged quadrant from `/Alarms/Active`, but relying on an omission in
another repo is the sort of implicit encoding this branch exists to remove.
Both now name both axes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: 0b45b66c-a1bf-46b0-9562-f2634a6ff881
